### PR TITLE
增加editorconfig文件,统一设置缩进格式

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig: http://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
增加editorconfig文件,统一设置缩进格式
配置所有文件两个空格缩进，utf8编码，\n换行，删除行尾空白，文件结尾增加空行

md文件不会删除行尾空白
