### PR TITLE
修改Token/Ticket的同步机制以支持集群

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpConfigStorage.java
@@ -5,6 +5,7 @@ import me.chanjar.weixin.common.util.http.ApacheHttpClientBuilder;
 
 import javax.net.ssl.SSLContext;
 import java.io.File;
+import java.util.concurrent.locks.Lock;
 
 /**
  * 微信客户端配置存储
@@ -14,6 +15,8 @@ import java.io.File;
 public interface WxMpConfigStorage {
 
   String getAccessToken();
+
+  Lock getAccessTokenLock();
 
   boolean isAccessTokenExpired();
 
@@ -37,6 +40,8 @@ public interface WxMpConfigStorage {
 
   String getJsapiTicket();
 
+  Lock getJsapiTicketLock();
+
   boolean isJsapiTicketExpired();
 
   /**
@@ -52,6 +57,8 @@ public interface WxMpConfigStorage {
   void updateJsapiTicket(String jsapiTicket, int expiresInSeconds);
 
   String getCardApiTicket();
+
+  Lock getCardApiTicketLock();
 
   boolean isCardApiTicketExpired();
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpInMemoryConfigStorage.java
@@ -6,6 +6,8 @@ import me.chanjar.weixin.common.util.http.ApacheHttpClientBuilder;
 
 import javax.net.ssl.SSLContext;
 import java.io.File;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * 基于内存的微信配置provider，在实际生产环境中应该将这些配置持久化
@@ -36,6 +38,10 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
   protected volatile String cardApiTicket;
   protected volatile long cardApiTicketExpiresTime;
 
+  protected Lock accessTokenLock = new ReentrantLock();
+  protected Lock jsapiTicketLock = new ReentrantLock();
+  protected Lock cardApiTicketLock = new ReentrantLock();
+
   /**
    * 临时文件目录
    */
@@ -48,6 +54,11 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
   @Override
   public String getAccessToken() {
     return this.accessToken;
+  }
+
+  @Override
+  public Lock getAccessTokenLock() {
+    return this.accessTokenLock;
   }
 
   @Override
@@ -74,6 +85,11 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
   @Override
   public String getJsapiTicket() {
     return this.jsapiTicket;
+  }
+
+  @Override
+  public Lock getJsapiTicketLock() {
+    return this.jsapiTicketLock;
   }
 
   public void setJsapiTicket(String jsapiTicket) {
@@ -111,6 +127,11 @@ public class WxMpInMemoryConfigStorage implements WxMpConfigStorage {
   @Override
   public String getCardApiTicket() {
     return this.cardApiTicket;
+  }
+
+  @Override
+  public Lock getCardApiTicketLock() {
+    return this.cardApiTicketLock;
   }
 
   @Override

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpServiceImpl.java
@@ -28,22 +28,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.concurrent.locks.Lock;
 
 public class WxMpServiceImpl implements WxMpService {
 
   private static final JsonParser JSON_PARSER = new JsonParser();
 
   protected final Logger log = LoggerFactory.getLogger(this.getClass());
-
-  /**
-   * 全局的是否正在刷新access token的锁
-   */
-  private final Object globalAccessTokenRefreshLock = new Object();
-
-  /**
-   * 全局的是否正在刷新jsapi_ticket的锁
-   */
-  private final Object globalJsapiTicketRefreshLock = new Object();
 
   private WxMpConfigStorage configStorage;
 
@@ -98,39 +89,42 @@ public class WxMpServiceImpl implements WxMpService {
 
   @Override
   public String getAccessToken(boolean forceRefresh) throws WxErrorException {
-    if (forceRefresh) {
-      this.configStorage.expireAccessToken();
-    }
+    Lock lock = configStorage.getAccessTokenLock();
+    try {
+      lock.lock();
 
-    if (this.configStorage.isAccessTokenExpired()) {
-      synchronized (this.globalAccessTokenRefreshLock) {
-        if (this.configStorage.isAccessTokenExpired()) {
-          String url = "https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential" +
-              "&appid=" + this.configStorage.getAppId() + "&secret="
-              + this.configStorage.getSecret();
-          try {
-            HttpGet httpGet = new HttpGet(url);
-            if (this.httpProxy != null) {
-              RequestConfig config = RequestConfig.custom().setProxy(this.httpProxy).build();
-              httpGet.setConfig(config);
-            }
-            try (CloseableHttpResponse response = getHttpclient().execute(httpGet)) {
-              String resultContent = new BasicResponseHandler().handleResponse(response);
-              WxError error = WxError.fromJson(resultContent);
-              if (error.getErrorCode() != 0) {
-                throw new WxErrorException(error);
-              }
-              WxAccessToken accessToken = WxAccessToken.fromJson(resultContent);
-              this.configStorage.updateAccessToken(accessToken.getAccessToken(),
-                  accessToken.getExpiresIn());
-            }finally {
-              httpGet.releaseConnection();
-            }
-          } catch (IOException e) {
-            throw new RuntimeException(e);
+      if (forceRefresh) {
+        this.configStorage.expireAccessToken();
+      }
+
+      if (this.configStorage.isAccessTokenExpired()) {
+        String url = "https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential" +
+            "&appid=" + this.configStorage.getAppId() + "&secret="
+            + this.configStorage.getSecret();
+        try {
+          HttpGet httpGet = new HttpGet(url);
+          if (this.httpProxy != null) {
+            RequestConfig config = RequestConfig.custom().setProxy(this.httpProxy).build();
+            httpGet.setConfig(config);
           }
+          try (CloseableHttpResponse response = getHttpclient().execute(httpGet)) {
+            String resultContent = new BasicResponseHandler().handleResponse(response);
+            WxError error = WxError.fromJson(resultContent);
+            if (error.getErrorCode() != 0) {
+              throw new WxErrorException(error);
+            }
+            WxAccessToken accessToken = WxAccessToken.fromJson(resultContent);
+            this.configStorage.updateAccessToken(accessToken.getAccessToken(),
+                accessToken.getExpiresIn());
+          }finally {
+            httpGet.releaseConnection();
+          }
+        } catch (IOException e) {
+          throw new RuntimeException(e);
         }
       }
+    } finally {
+      lock.unlock();
     }
     return this.configStorage.getAccessToken();
   }
@@ -142,22 +136,25 @@ public class WxMpServiceImpl implements WxMpService {
 
   @Override
   public String getJsapiTicket(boolean forceRefresh) throws WxErrorException {
-    if (forceRefresh) {
-      this.configStorage.expireJsapiTicket();
-    }
+    Lock lock = configStorage.getJsapiTicketLock();
+    try {
+      lock.lock();
 
-    if (this.configStorage.isJsapiTicketExpired()) {
-      synchronized (this.globalJsapiTicketRefreshLock) {
-        if (this.configStorage.isJsapiTicketExpired()) {
-          String url = "https://api.weixin.qq.com/cgi-bin/ticket/getticket?type=jsapi";
-          String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
-          JsonElement tmpJsonElement = JSON_PARSER.parse(responseContent);
-          JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();
-          String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
-          int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
-          this.configStorage.updateJsapiTicket(jsapiTicket, expiresInSeconds);
-        }
+      if (forceRefresh) {
+        this.configStorage.expireJsapiTicket();
       }
+
+      if (this.configStorage.isJsapiTicketExpired()) {
+        String url = "https://api.weixin.qq.com/cgi-bin/ticket/getticket?type=jsapi";
+        String responseContent = execute(new SimpleGetRequestExecutor(), url, null);
+        JsonElement tmpJsonElement = JSON_PARSER.parse(responseContent);
+        JsonObject tmpJsonObject = tmpJsonElement.getAsJsonObject();
+        String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
+        int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
+        this.configStorage.updateJsapiTicket(jsapiTicket, expiresInSeconds);
+      }
+    } finally {
+      lock.unlock();
     }
     return this.configStorage.getJsapiTicket();
   }


### PR DESCRIPTION
目前对于AccessToken、JsapiTicket和CardApiTicket在更新时的同步都是通过synchronized关键词来实现的，这样在进行集群时会有问题。
这个补丁修改了这些接口的同步机制，使用锁进行同步，并由WxMpConfigStorage提供锁的具体实现。在默认的WxMpInMemoryConfigStorage中直接使用了ReentrantLock来提供单服务器中多线程的同步。
对于需要集群的场景，可以通过缓存中间件来实现WxMpConfigStorage和Lock。以Redis为例，开发者只需提供Redis版的WxMpConfigStorage和Redis版本的锁实现即可。

企业号也存在类似的问题，因为暂时没有涉及企业号的开发，因此没有对企业号做相应的修改和测试。