### PR TITLE
企业号oauth2认证接口返回值中添加openid

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpServiceImpl.java
@@ -491,7 +491,7 @@ public class WxCpServiceImpl implements WxCpService {
     String responseText = get(url, null);
     JsonElement je = new JsonParser().parse(responseText);
     JsonObject jo = je.getAsJsonObject();
-    return new String[]{GsonHelper.getString(jo, "UserId"), GsonHelper.getString(jo, "DeviceId")};
+    return new String[]{GsonHelper.getString(jo, "UserId"), GsonHelper.getString(jo, "DeviceId"), GsonHelper.getString(jo, "OpenId")};
   }
 
   @Override


### PR DESCRIPTION
非企业成员使用oauth2认证接口时, 企业号会返回用户的openId.