### PR TITLE
pay模块使用jodd-http方式，已支持证书方式

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceImpl.java
@@ -375,7 +375,6 @@ public class WxPayServiceImpl implements WxPayService {
   }
 
   /**
-   * 由于暂时未找到使用jodd-http实现证书配置的办法，故而暂时使用httpclient
    * ecoolper(20170418)，修改为jodd-http方式
    */
   private String postWithKey(String url, String requestStr) throws WxErrorException {
@@ -385,9 +384,9 @@ public class WxPayServiceImpl implements WxPayService {
         sslContext = this.getConfig().initSSLContext();
       }
 
-      HttpRequest request =HttpRequest.post(url).withConnectionProvider(new SSLSocketHttpConnectionProvider(sslContext));
+      HttpRequest request = HttpRequest.post(url).withConnectionProvider(new SSLSocketHttpConnectionProvider(sslContext));
       request.bodyText(requestStr);
-      HttpResponse response =request.send();
+      HttpResponse response = request.send();
       String result = response.bodyText();
       this.log.debug("\n[URL]:  {}\n[PARAMS]: {}\n[RESPONSE]: {}", url, requestStr, result);
       return result;

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/WxPayServiceImplTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/WxPayServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.github.binarywang.wxpay.service.impl;
 
+import static org.testng.Assert.*;
+
 import com.github.binarywang.utils.qrcode.QrcodeUtils;
 import com.github.binarywang.wxpay.bean.request.*;
 import com.github.binarywang.wxpay.bean.result.*;
@@ -10,14 +12,13 @@ import com.google.inject.Inject;
 import me.chanjar.weixin.common.exception.WxErrorException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.annotations.*;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-
-import static org.testng.Assert.*;
 
 /**
  * 测试支付相关接口
@@ -263,5 +264,6 @@ public class WxPayServiceImplTest {
     assertNotNull(result);
     this.logger.info(result);
   }
+
 
 }


### PR DESCRIPTION
1、pay模块使用jodd-http方式，已支持证书方式
2、使用证书的方式和httpclient一样，都是通过java.net.ssl.SSLContext获取机器中的证书