### PR TITLE
更新接口：临时二维码的场景值支持字符串

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpQrcodeService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpQrcodeService.java
@@ -26,6 +26,18 @@ public interface WxMpQrcodeService {
    */
   WxMpQrCodeTicket qrCodeCreateTmpTicket(int sceneId, Integer expireSeconds) throws WxErrorException;
 
+
+  /**
+   * <pre>
+   * 换取临时二维码ticket
+   * 详情请见: <a href="https://mp.weixin.qq.com/wiki?action=doc&id=mp1443433542&t=0.9274944716856435">生成带参数的二维码</a>
+   * </pre>
+   *
+   * @param sceneStr      场景值ID（字符串形式的ID），字符串类型，长度限制为1到64
+   * @param expireSeconds 该二维码有效时间，以秒为单位。 最大不超过2592000（即30天），此字段如果不填，则默认有效期为30秒。
+   */
+  WxMpQrCodeTicket qrCodeCreateTmpTicket(String sceneStr, Integer expireSeconds) throws WxErrorException;
+
   /**
    * <pre>
    * 换取永久二维码ticket

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImpl.java
@@ -7,6 +7,7 @@ import me.chanjar.weixin.mp.api.WxMpQrcodeService;
 import me.chanjar.weixin.mp.api.WxMpService;
 import me.chanjar.weixin.mp.bean.result.WxMpQrCodeTicket;
 import me.chanjar.weixin.mp.util.http.QrCodeRequestExecutor;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -53,6 +54,38 @@ public class WxMpQrcodeServiceImpl implements WxMpQrcodeService {
     String responseContent = this.wxMpService.post(url, json.toString());
     return WxMpQrCodeTicket.fromJson(responseContent);
   }
+
+
+  @Override
+  public WxMpQrCodeTicket qrCodeCreateTmpTicket(String sceneStr, Integer expireSeconds) throws WxErrorException {
+    if (StringUtils.isBlank(sceneStr)) {
+      throw new WxErrorException(WxError.newBuilder().setErrorCode(-1).setErrorMsg("临时二维码场景值不能为空！").build());
+    }
+
+    //expireSeconds 该二维码有效时间，以秒为单位。 最大不超过2592000（即30天），此字段如果不填，则默认有效期为30秒。
+    if (expireSeconds != null && expireSeconds > 2592000) {
+      throw new WxErrorException(WxError.newBuilder().setErrorCode(-1)
+        .setErrorMsg("临时二维码有效时间最大不能超过2592000（即30天）！").build());
+    }
+
+    if (expireSeconds == null) {
+      expireSeconds = 30;
+    }
+
+    String url = API_URL_PREFIX + "/create";
+    JsonObject json = new JsonObject();
+    json.addProperty("action_name", "QR_STR_SCENE");
+    json.addProperty("expire_seconds", expireSeconds);
+
+    JsonObject actionInfo = new JsonObject();
+    JsonObject scene = new JsonObject();
+    scene.addProperty("scene_str", sceneStr);
+    actionInfo.add("scene", scene);
+    json.add("action_info", actionInfo);
+    String responseContent = this.wxMpService.post(url, json.toString());
+    return WxMpQrCodeTicket.fromJson(responseContent);
+  }
+
 
   @Override
   public WxMpQrCodeTicket qrCodeCreateLastTicket(int sceneId) throws WxErrorException {

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImplTest.java
@@ -5,6 +5,7 @@ import me.chanjar.weixin.common.exception.WxErrorException;
 import me.chanjar.weixin.mp.api.WxMpService;
 import me.chanjar.weixin.mp.api.test.ApiTestModule;
 import me.chanjar.weixin.mp.bean.result.WxMpQrCodeTicket;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.testng.*;
 import org.testng.annotations.*;
 
@@ -26,9 +27,24 @@ public class WxMpQrcodeServiceImplTest {
     return new Object[][]{{-1}, {0}, {1}, {200000}};
   }
 
+  @DataProvider
+  public Object[][] sceneStrs() {
+    return new Object[][]{{null}, {""}, {"test"}, {RandomStringUtils.randomAlphanumeric(100)}};
+  }
+
   @Test(dataProvider = "sceneIds")
   public void testQrCodeCreateTmpTicket(int sceneId) throws WxErrorException {
     WxMpQrCodeTicket ticket = this.wxService.getQrcodeService().qrCodeCreateTmpTicket(sceneId, null);
+    Assert.assertNotNull(ticket.getUrl());
+    Assert.assertNotNull(ticket.getTicket());
+    Assert.assertTrue(ticket.getExpire_seconds() != -1);
+    System.out.println(ticket);
+  }
+
+
+  @Test(dataProvider = "sceneStrs")
+  public void testQrCodeCreateTmpTicketWithSceneStr(String sceneStr) throws WxErrorException {
+    WxMpQrCodeTicket ticket = this.wxService.getQrcodeService().qrCodeCreateTmpTicket(sceneStr, null);
     Assert.assertNotNull(ticket.getUrl());
     Assert.assertNotNull(ticket.getTicket());
     Assert.assertTrue(ticket.getExpire_seconds() != -1);


### PR DESCRIPTION
创建二维码ticket接口的场景值已经支持字符串
[生成带参数的二维码](https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1443433542)