### PR TITLE
Patch 1

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpQrcodeService.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/WxMpQrcodeService.java
@@ -25,6 +25,17 @@ public interface WxMpQrcodeService {
    * @param expireSeconds 该二维码有效时间，以秒为单位。 最大不超过2592000（即30天），此字段如果不填，则默认有效期为30秒。
    */
   WxMpQrCodeTicket qrCodeCreateTmpTicket(int sceneId, Integer expireSeconds) throws WxErrorException;
+  
+  /**
+   * <pre>
+   * 换取临时二维码ticket
+   * 详情请见: <a href="https://mp.weixin.qq.com/wiki?action=doc&id=mp1443433542&t=0.9274944716856435">生成带参数的二维码</a>
+   * </pre>
+   *
+   * @param sceneStr      参数。字符串类型长度现在为1到64
+   * @param expireSeconds 该二维码有效时间，以秒为单位。 最大不超过2592000（即30天），此字段如果不填，则默认有效期为30秒。
+   */
+  WxMpQrCodeTicket qrCodeCreateTmpTicket(String sceneStr, Integer expireSeconds) throws WxErrorException;
 
   /**
    * <pre>

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpQrcodeServiceImpl.java
@@ -53,6 +53,32 @@ public class WxMpQrcodeServiceImpl implements WxMpQrcodeService {
     String responseContent = this.wxMpService.post(url, json.toString());
     return WxMpQrCodeTicket.fromJson(responseContent);
   }
+  
+  @Override
+  public WxMpQrCodeTicket qrCodeCreateTmpTicket(String sceneStr, Integer expireSeconds) throws WxErrorException {
+	      //expireSeconds 该二维码有效时间，以秒为单位。 最大不超过2592000（即30天），此字段如果不填，则默认有效期为30秒。
+	      if (expireSeconds != null && expireSeconds > 2592000) {
+	        throw new WxErrorException(WxError.newBuilder().setErrorCode(-1)
+	          .setErrorMsg("临时二维码有效时间最大不能超过2592000（即30天）！").build());
+	      }
+
+	      if (expireSeconds == null) {
+	        expireSeconds = 30;
+	      }
+
+	      String url = API_URL_PREFIX + "/create";
+	      JsonObject json = new JsonObject();
+	      json.addProperty("action_name", "QR_LIMIT_STR_SCENE");
+	      json.addProperty("expire_seconds", expireSeconds);
+
+	      JsonObject actionInfo = new JsonObject();
+	      JsonObject scene = new JsonObject();
+	      scene.addProperty("scene_str", sceneStr);
+	      actionInfo.add("scene", scene);
+	      json.add("action_info", actionInfo);
+	      String responseContent = this.wxMpService.post(url, json.toString());
+	      return WxMpQrCodeTicket.fromJson(responseContent);
+  }
 
   @Override
   public WxMpQrCodeTicket qrCodeCreateLastTicket(int sceneId) throws WxErrorException {


### PR DESCRIPTION
在某些场景下，我们需要通过二维码传递String类型的参数，且该二维码只需要临时使用，但目前的sdk中好像没有提供对应生成带String类型参数的临时二维码的api，我查了官方文档，发现是允许这么做的，所以我加上了这个，希望有帮助。
ps:是这么推代码的吗 没操作过。。。