### PR TITLE
修复服务商模式下,使用仅有sub_openid时,无法预下单的问题.

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayUnifiedOrderRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayUnifiedOrderRequest.java
@@ -506,8 +506,8 @@ public class WxPayUnifiedOrderRequest extends WxPayBaseRequest {
 //        Arrays.toString(TRADE_TYPES), this.getTradeType()));
 //    }
 
-    if ("JSAPI".equals(this.getTradeType()) && this.getOpenid() == null) {
-      throw new WxPayException("当 trade_type是'JSAPI'时未指定openid");
+    if ("JSAPI".equals(this.getTradeType()) && this.getOpenid() == null && this.getSubOpenid() == null) {
+      throw new WxPayException("当 trade_type是'JSAPI'时未指定openid或subOpenId");
     }
 
     if ("NATIVE".equals(this.getTradeType()) && this.getProductId() == null) {

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayUnifiedOrderRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayUnifiedOrderRequest.java
@@ -507,7 +507,7 @@ public class WxPayUnifiedOrderRequest extends WxPayBaseRequest {
 //    }
 
     if ("JSAPI".equals(this.getTradeType()) && this.getOpenid() == null && this.getSubOpenid() == null) {
-      throw new WxPayException("当 trade_type是'JSAPI'时未指定openid或subOpenId");
+      throw new WxPayException("当 trade_type是'JSAPI'时未指定openid或sub_openid");
     }
 
     if ("NATIVE".equals(this.getTradeType()) && this.getProductId() == null) {


### PR DESCRIPTION
修复服务商模式下,使用仅有sub_openid时,无法预下单的问题.按微信统一下单接口说明，JSAPI模式下，openid或sub_openid必须存在，且存在其一即可。