### PR TITLE
去掉 pom.xml 中无用的代码

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ language: java
 
 jdk:
   - oraclejdk8
-script: "mvn clean package -Dmaven.test.skip=true"
-    
+script: "./mvnw clean package -DskipTests=true"
+
 #script:
 #  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar
-  
+
 branches:
   only:
     - develop
-  
+
 cache:
   directories:
     - '$HOME/.m2/repository'

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,6 @@
     <maven.compiler.target>1.7</maven.compiler.target>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <downloadJavadocs>true</downloadJavadocs>
-    <downloadSources>true</downloadSources>
     <httpclient.version>4.5</httpclient.version>
     <jetty.version>9.3.0.RC0</jetty.version>
   </properties>
@@ -324,19 +322,6 @@
   </profiles>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
@@ -360,15 +345,6 @@
           <goals>deploy</goals>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
更改清单：
1. 去掉了`maven-compiler-plugin`的编码配置，因为已经有了`<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>`property配置， 二者是一样的
2. 默认情况下不应跳过单元测试，如需跳过测试可通过`-DskipTests=true`
3. 默认情况下不应下载源代码与`Javadoc`，因为并不是所有情况都需要源代码与javadoc，例如CI构建时。