### PR TITLE
新功能-《获取企业号应用》接口功能

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpAgentService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpAgentService.java
@@ -1,0 +1,29 @@
+package me.chanjar.weixin.cp.api;
+
+import me.chanjar.weixin.common.exception.WxErrorException;
+import me.chanjar.weixin.cp.bean.WxCpAgent;
+import me.chanjar.weixin.cp.bean.WxCpDepart;
+
+/**
+ * <pre>
+ *  管理企业号应用
+ *  Created by huansinho on 2018/4/13.
+ * </pre>
+ *
+ * @author <a href="https://github.com/huansinho">huansinho</a>
+ */
+public interface WxCpAgentService {
+
+  /**
+   * <pre>
+   * 获取企业号应用信息
+   * 该API用于获取企业号某个应用的基本信息，包括头像、昵称、帐号类型、认证类型、可见范围等信息
+   * 详情请见: http://qydev.weixin.qq.com/wiki/index.php?title=获取企业号应用
+   * </pre>
+   *
+   * @param agentId 企业应用的id
+   * @return 部门id
+   */
+  WxCpAgent get(Integer agentId) throws WxErrorException;
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
@@ -249,6 +249,8 @@ public interface WxCpService {
    */
   WxCpUserService getUserService();
 
+  WxCpAgentService getAgentService();
+
   /**
    * http请求对象
    */

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImpl.java
@@ -1,0 +1,44 @@
+package me.chanjar.weixin.cp.api.impl;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+import me.chanjar.weixin.common.exception.WxErrorException;
+import me.chanjar.weixin.cp.api.WxCpAgentService;
+import me.chanjar.weixin.cp.api.WxCpService;
+import me.chanjar.weixin.cp.bean.WxCpAgent;
+import me.chanjar.weixin.cp.bean.WxCpDepart;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.List;
+
+
+/**
+ * <pre>
+ *  管理企业号应用
+ *  Created by huansinho on 2018/4/13.
+ * </pre>
+ *
+ * @author <a href="https://github.com/huansinho">huansinho</a>
+ */
+public class WxCpAgentServiceImpl implements WxCpAgentService {
+  private WxCpService mainService;
+
+  public WxCpAgentServiceImpl(WxCpService mainService) {
+    this.mainService = mainService;
+  }
+
+  @Override
+  public WxCpAgent get(Integer agentId) throws WxErrorException {
+
+    String url = "https://qyapi.weixin.qq.com/cgi-bin/agent/get";
+    if (agentId != null) {
+      url += "?agentid=" + agentId;
+    } else {
+      throw new IllegalArgumentException("缺少agentid参数");
+    }
+    String responseContent = this.mainService.get(url, null);
+    return WxCpAgent.fromJson(responseContent);
+  }
+
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceAbstractImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceAbstractImpl.java
@@ -39,6 +39,7 @@ public abstract class WxCpServiceAbstractImpl<H, P> implements WxCpService, Requ
   private WxCpMenuService menuService = new WxCpMenuServiceImpl(this);
   private WxCpOAuth2Service oauth2Service = new WxCpOAuth2ServiceImpl(this);
   private WxCpTagService tagService = new WxCpTagServiceImpl(this);
+  private WxCpAgentService agentService = new WxCpAgentServiceImpl(this);
 
   /**
    * 全局的是否正在刷新access token的锁
@@ -367,5 +368,14 @@ public abstract class WxCpServiceAbstractImpl<H, P> implements WxCpService, Requ
   @Override
   public void setTagService(WxCpTagService tagService) {
     this.tagService = tagService;
+  }
+
+  @Override
+  public WxCpAgentService getAgentService() {
+    return agentService;
+  }
+
+  public void setAgentService(WxCpAgentService agentService) {
+    this.agentService = agentService;
   }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpAgent.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpAgent.java
@@ -1,0 +1,96 @@
+package me.chanjar.weixin.cp.bean;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * <pre>
+ * 企业号应用信息.
+ * Created by huansinho on 2018/4/13.
+ * </pre>
+ *
+ * @author <a href="https://github.com/huansinho">huansinho</a>
+ */
+@Data
+public class WxCpAgent implements Serializable {
+
+  @SerializedName("errcode")
+  private Integer errcode;
+
+  @SerializedName("errmsg")
+  private String errmsg;
+
+  @SerializedName("agentid")
+  private Integer agentid;
+
+  @SerializedName("name")
+  private String name;
+
+  @SerializedName("square_logo_url")
+  private String squareLogoUrl;
+
+  @SerializedName("description")
+  private String description;
+
+  @SerializedName("allow_userinfos")
+  private Users allowUserinfos;
+
+  @SerializedName("allow_partys")
+  private Partys allowPartys;
+
+  @SerializedName("allow_tags")
+  private Tags allowTags;
+
+  @SerializedName("close")
+  private Integer close;
+
+  @SerializedName("redirect_domain")
+  private String redirectDomain;
+
+  @SerializedName("report_location_flag")
+  private Integer reportLocationFlag;
+
+  @SerializedName("isreportenter")
+  private Integer isreportenter;
+
+  @SerializedName("home_url")
+  private String homeUrl;
+
+  public static WxCpAgent fromJson(String json) {
+    return WxCpGsonBuilder.create().fromJson(json, WxCpAgent.class);
+  }
+
+  public String toJson() {
+    return WxCpGsonBuilder.create().toJson(this);
+  }
+
+  @Data
+  public static class Users implements Serializable {
+    @SerializedName("user")
+    private List<User> user;
+  }
+
+
+  @Data
+  public class User implements Serializable {
+    @SerializedName("userid")
+    private String userid;
+  }
+
+  @Data
+  public class Partys {
+    @SerializedName("partyid")
+    private List<Integer> partyids = null;
+  }
+
+  @Data
+  public class Tags {
+    @SerializedName("tagid")
+    private List<Integer> tagids = null;
+  }
+
+}

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImplTest.java
@@ -1,0 +1,52 @@
+package me.chanjar.weixin.cp.api.impl;
+
+import com.google.inject.Inject;
+import me.chanjar.weixin.common.api.WxConsts;
+import me.chanjar.weixin.common.bean.menu.WxMenu;
+import me.chanjar.weixin.common.bean.menu.WxMenuButton;
+import me.chanjar.weixin.cp.api.ApiTestModule;
+import me.chanjar.weixin.cp.api.WxCpAgentService;
+import me.chanjar.weixin.cp.api.WxCpService;
+import me.chanjar.weixin.cp.bean.WxCpAgent;
+import me.chanjar.weixin.cp.config.WxCpInMemoryConfigStorage;
+import org.mockito.Mock;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * <pre>
+ *  管理企业号应用-测试
+ *  Created by huansinho on 2018/4/13.
+ * </pre>
+ *
+ * @author <a href="https://github.com/huansinho">huansinho</a>
+ */
+public class WxCpAgentServiceImplTest {
+
+  protected WxCpService wxService = mock(WxCpService.class);
+
+  @Test
+  public void testGet() throws Exception {
+    String returnJson = "{\"errcode\": 0,\"errmsg\": \"ok\",\"agentid\": 9,\"name\": \"测试应用\",\"square_logo_url\": \"http://wx.qlogo.cn/mmhead/alksjf;lasdjf;lasjfuodiuj3rj2o34j/0\",\"description\": \"这是一个企业号应用\",\"allow_userinfos\": {\"user\": [{\"userid\": \"0009854\"}, {\"userid\": \"1723\"}, {\"userid\": \"5625\"}]},\"allow_partys\": {\"partyid\": [42762742]},\"allow_tags\": {\"tagid\": [23, 22, 35, 19, 32, 125, 133, 46, 150, 38, 183, 9, 7]},\"close\": 0,\"redirect_domain\": \"weixin.com.cn\",\"report_location_flag\": 0,\"isreportenter\": 0,\"home_url\": \"\"}";
+    when(wxService.get("https://qyapi.weixin.qq.com/cgi-bin/agent/get?agentid=9", null)).thenReturn(returnJson);
+    when(wxService.getAgentService()).thenReturn(new WxCpAgentServiceImpl(wxService));
+
+    WxCpAgentService wxAgentService = this.wxService.getAgentService();
+    WxCpAgent wxCpAgent = wxAgentService.get(9);
+
+    Assert.assertEquals(9, wxCpAgent.getAgentid().intValue());
+
+    Assert.assertEquals(new Integer[]{42762742}, wxCpAgent.getAllowPartys().getPartyids().toArray());
+
+    Assert.assertEquals(new Integer[]{23, 22, 35, 19, 32, 125, 133, 46, 150, 38, 183, 9, 7}, wxCpAgent.getAllowTags().getTagids().toArray());
+
+  }
+
+}

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/bean/WxCpAgentTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/bean/WxCpAgentTest.java
@@ -1,0 +1,25 @@
+package me.chanjar.weixin.cp.bean;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Created by huansinho on 2018/4/13.
+ */
+@Test
+public class WxCpAgentTest {
+
+  public void testDeserialize() {
+    String json = "{\"errcode\": 0,\"errmsg\": \"ok\",\"agentid\": 9,\"name\": \"测试应用\",\"square_logo_url\": \"http://wx.qlogo.cn/mmhead/alksjf;lasdjf;lasjfuodiuj3rj2o34j/0\",\"description\": \"这是一个企业号应用\",\"allow_userinfos\": {\"user\": [{\"userid\": \"0009854\"}, {\"userid\": \"1723\"}, {\"userid\": \"5625\"}]},\"allow_partys\": {\"partyid\": [42762742]},\"allow_tags\": {\"tagid\": [23, 22, 35, 19, 32, 125, 133, 46, 150, 38, 183, 9, 7]},\"close\": 0,\"redirect_domain\": \"weixin.com.cn\",\"report_location_flag\": 0,\"isreportenter\": 0,\"home_url\": \"\"}";
+
+    WxCpAgent wxCpAgent = WxCpAgent.fromJson(json);
+
+    Assert.assertEquals(9, wxCpAgent.getAgentid().intValue());
+
+    Assert.assertEquals(new Integer[]{42762742}, wxCpAgent.getAllowPartys().getPartyids().toArray());
+
+    Assert.assertEquals(new Integer[]{23, 22, 35, 19, 32, 125, 133, 46, 150, 38, 183, 9, 7}, wxCpAgent.getAllowTags().getTagids().toArray());
+
+  }
+
+}


### PR DESCRIPTION
增加《获取企业号应用》接口功能
该API用于获取企业号某个应用的基本信息，包括头像、昵称、帐号类型、认证类型、可见范围等信息
详情请见: http://qydev.weixin.qq.com/wiki/index.php?title=获取企业号应用