### PR TITLE
修改了退款结果通知类WxPayRefundNotifyResult中的fromXML方法

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayRefundNotifyResult.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayRefundNotifyResult.java
@@ -46,6 +46,10 @@ public class WxPayRefundNotifyResult extends BaseWxPayResult implements Serializ
    */
   public static WxPayRefundNotifyResult fromXML(String xmlString, String mchKey) throws WxPayException {
     WxPayRefundNotifyResult result = BaseWxPayResult.fromXML(xmlString, WxPayRefundNotifyResult.class);
+    if ("FAIL".equals(result.getReturnCode())) {
+      return result;
+    }
+    
     String reqInfoString = result.getReqInfoString();
     try {
       final String keyMd5String = DigestUtils.md5Hex(mchKey).toLowerCase();


### PR DESCRIPTION
如果return_code为FAIL时，没有加密信息req_info，因此后面的加密处理会抛出异常。
因此return_code为FAIL时，直接返回结果。