### PR TITLE
#869 修复下载临时素材接口异常处理不当的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ sonar-project.properties
 
 !/.mvn/wrapper/maven-wrapper.jar
 *.versionsBackup
+
+# STS
+.factorypath

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/HttpResponseProxy.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/HttpResponseProxy.java
@@ -58,7 +58,7 @@ public class HttpResponseProxy {
   private String getFileName(CloseableHttpResponse response) throws WxErrorException {
     Header[] contentDispositionHeader = response.getHeaders("Content-disposition");
     if (contentDispositionHeader == null || contentDispositionHeader.length == 0) {
-      throw new WxErrorException(WxError.builder().errorMsg("无法获取到文件名").build());
+      throw new WxErrorException(WxError.builder().errorMsg("无法获取到文件名").errorCode(99999).build());
     }
 
     return this.extractFileNameFromContentString(contentDispositionHeader[0].getValue());
@@ -76,7 +76,7 @@ public class HttpResponseProxy {
 
   private String extractFileNameFromContentString(String content) throws WxErrorException {
     if (content == null || content.length() == 0) {
-      throw new WxErrorException(WxError.builder().errorMsg("无法获取到文件名").build());
+      throw new WxErrorException(WxError.builder().errorMsg("无法获取到文件名").errorCode(99999).build());
     }
 
     Matcher m = PATTERN.matcher(content);
@@ -84,7 +84,7 @@ public class HttpResponseProxy {
       return m.group(1);
     }
 
-    throw new WxErrorException(WxError.builder().errorMsg("无法获取到文件名").build());
+    throw new WxErrorException(WxError.builder().errorMsg("无法获取到文件名").errorCode(99999).build());
   }
 
 }


### PR DESCRIPTION
Spring Tools Suite 生成的配置文件，需要被忽略掉