### PR TITLE
Fix issue Wechat-Group#741: 关于公众号模块对session管理的体验以及建议

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
@@ -176,6 +176,13 @@ public interface WxCpService {
   void setSessionManager(WxSessionManager sessionManager);
 
   /**
+   * 获取WxSessionManager.
+   * WxCpService默认使用的是{@link me.chanjar.weixin.common.session.StandardSessionManager}
+   *
+   */
+  WxSessionManager getSessionManager();
+  
+  /**
    * 上传部门列表覆盖企业号上的部门信息
    *
    * @param mediaId 媒体id

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/BaseWxCpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/BaseWxCpServiceImpl.java
@@ -286,6 +286,11 @@ public abstract class BaseWxCpServiceImpl<H, P> implements WxCpService, RequestH
   }
 
   @Override
+  public WxSessionManager getSessionManager() {
+    return this.sessionManager;
+  }
+
+  @Override
   public String replaceParty(String mediaId) throws WxErrorException {
     String url = "https://qyapi.weixin.qq.com/cgi-bin/batch/replaceparty";
     JsonObject jsonObject = new JsonObject();

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/message/WxCpMessageRouter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/message/WxCpMessageRouter.java
@@ -73,7 +73,7 @@ public class WxCpMessageRouter {
     this.wxCpService = wxCpService;
     this.executorService = Executors.newFixedThreadPool(DEFAULT_THREAD_POOL_SIZE);
     this.messageDuplicateChecker = new WxMessageInMemoryDuplicateChecker();
-    this.sessionManager = new StandardSessionManager();
+    this.sessionManager = wxCpService.getSessionManager();
     this.exceptionHandler = new LogExceptionHandler();
   }
 


### PR DESCRIPTION
WxCpMessageRouter没有使用wxCpService创建的默认的StandardSessionManager，而是自己重新创建了一个，这样有两个StandardSessionManager存在，导致数据的不一致。
现在把wxCpService添加getSessionManager方法。这样在WxCpMessageRouter中使用wxCpService的StandardSessionManager，就避免了这个问题。