### PR TITLE
修正企业微信部门管理接口中的注释

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpDepartmentService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpDepartmentService.java
@@ -19,7 +19,7 @@ public interface WxCpDepartmentService {
    * <pre>
    * 部门管理接口 - 创建部门.
    * 最多支持创建500个部门
-   * 详情请见: http://mp.weixin.qq.com/wiki/index.php?title=部门管理接口
+   * 详情请见: https://work.weixin.qq.com/api/doc#90000/90135/90205
    * </pre>
    *
    * @param depart 部门
@@ -30,8 +30,8 @@ public interface WxCpDepartmentService {
 
   /**
    * <pre>
-   * 部门管理接口 - 查询部门.
-   * 详情请见: http://qydev.weixin.qq.com/wiki/index.php?title=%E7%AE%A1%E7%90%86%E9%83%A8%E9%97%A8#.E8.8E.B7.E5.8F.96.E9.83.A8.E9.97.A8.E5.88.97.E8.A1.A8
+   * 部门管理接口 - 获取部门列表.
+   * 详情请见: https://work.weixin.qq.com/api/doc#90000/90135/90208
    * </pre>
    *
    * @param id 部门id。获取指定部门及其下的子部门。非必需，可为null
@@ -41,8 +41,8 @@ public interface WxCpDepartmentService {
 
   /**
    * <pre>
-   * 部门管理接口 - 修改部门名.
-   * 详情请见: http://mp.weixin.qq.com/wiki/index.php?title=部门管理接口
+   * 部门管理接口 - 更新部门.
+   * 详情请见: https://work.weixin.qq.com/api/doc#90000/90135/90206
    * 如果id为0(未部门),1(黑名单),2(星标组)，或者不存在的id，微信会返回系统繁忙的错误
    * </pre>
    *
@@ -54,6 +54,8 @@ public interface WxCpDepartmentService {
   /**
    * <pre>
    * 部门管理接口 - 删除部门.
+   * 详情请见: https://work.weixin.qq.com/api/doc#90000/90135/90207
+   * 应用须拥有指定部门的管理权限
    * </pre>
    *
    * @param departId 部门id

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpDepartmentService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpDepartmentService.java
@@ -35,6 +35,7 @@ public interface WxCpDepartmentService {
    * </pre>
    *
    * @param id 部门id。获取指定部门及其下的子部门。非必需，可为null
+   * @return 获取的部门列表
    * @throws WxErrorException 异常
    */
   List<WxCpDepart> list(Long id) throws WxErrorException;


### PR DESCRIPTION
1. 注释中对应的企业微信文档url已经过时，更正该部分
2. 部分方法注释不符合javadoc规范，对其进行完善