### PR TITLE
支持私有安装版企业微信.

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpAgentService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpAgentService.java
@@ -15,9 +15,9 @@ import java.util.List;
  * @author <a href="https://github.com/huansinho">huansinho</a>
  */
 public interface WxCpAgentService {
-  String GET_AGENT = "https://qyapi.weixin.qq.com/cgi-bin/agent/get?agentid=%d";
-  String AGENT_SET = "https://qyapi.weixin.qq.com/cgi-bin/agent/set";
-  String AGENT_LIST = "https://qyapi.weixin.qq.com/cgi-bin/agent/list";
+  String GET_AGENT = "/cgi-bin/agent/get?agentid=%d";
+  String AGENT_SET = "`/cgi-bin/agent/set";
+  String AGENT_LIST = "/cgi-bin/agent/list";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpChatService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpChatService.java
@@ -12,10 +12,10 @@ import java.util.List;
  * @author gaigeshen
  */
 public interface WxCpChatService {
-  String APPCHAT_CREATE = "https://qyapi.weixin.qq.com/cgi-bin/appchat/create";
-  String APPCHAT_UPDATE = "https://qyapi.weixin.qq.com/cgi-bin/appchat/update";
-  String APPCHAT_GET_CHATID = "https://qyapi.weixin.qq.com/cgi-bin/appchat/get?chatid=";
-  String APPCHAT_SEND = "https://qyapi.weixin.qq.com/cgi-bin/appchat/send";
+  String APPCHAT_CREATE = "/cgi-bin/appchat/create";
+  String APPCHAT_UPDATE = "/cgi-bin/appchat/update";
+  String APPCHAT_GET_CHATID = "/cgi-bin/appchat/get?chatid=";
+  String APPCHAT_SEND = "/cgi-bin/appchat/send";
 
   @Deprecated
   String chatCreate(String name, String owner, List<String> users, String chatId) throws WxErrorException;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpDepartmentService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpDepartmentService.java
@@ -1,9 +1,9 @@
 package me.chanjar.weixin.cp.api;
 
-import java.util.List;
-
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.cp.bean.WxCpDepart;
+
+import java.util.List;
 
 /**
  * <pre>
@@ -14,10 +14,10 @@ import me.chanjar.weixin.cp.bean.WxCpDepart;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 public interface WxCpDepartmentService {
-  String DEPARTMENT_CREATE = "https://qyapi.weixin.qq.com/cgi-bin/department/create";
-  String DEPARTMENT_UPDATE = "https://qyapi.weixin.qq.com/cgi-bin/department/update";
-  String DEPARTMENT_DELETE = "https://qyapi.weixin.qq.com/cgi-bin/department/delete?id=%d";
-  String DEPARTMENT_LIST = "https://qyapi.weixin.qq.com/cgi-bin/department/list";
+  String DEPARTMENT_CREATE = "/cgi-bin/department/create";
+  String DEPARTMENT_UPDATE = "/cgi-bin/department/update";
+  String DEPARTMENT_DELETE = "/cgi-bin/department/delete?id=%d";
+  String DEPARTMENT_LIST = "/cgi-bin/department/list";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMediaService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMediaService.java
@@ -1,11 +1,11 @@
 package me.chanjar.weixin.cp.api;
 
+import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
+import me.chanjar.weixin.common.error.WxErrorException;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-
-import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
-import me.chanjar.weixin.common.error.WxErrorException;
 
 /**
  * <pre>
@@ -16,10 +16,10 @@ import me.chanjar.weixin.common.error.WxErrorException;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 public interface WxCpMediaService {
-  String MEDIA_GET_URL = "https://qyapi.weixin.qq.com/cgi-bin/media/get";
-  String MEDIA_UPLOAD_URL = "https://qyapi.weixin.qq.com/cgi-bin/media/upload?type=";
-  String IMG_UPLOAD_URL = "https://qyapi.weixin.qq.com/cgi-bin/media/uploadimg";
-  String JSSDK_MEDIA_GET_URL = "https://qyapi.weixin.qq.com/cgi-bin/media/get/jssdk";
+  String MEDIA_GET_URL = "/cgi-bin/media/get";
+  String MEDIA_UPLOAD_URL = "/cgi-bin/media/upload?type=";
+  String IMG_UPLOAD_URL = "/cgi-bin/media/uploadimg";
+  String JSSDK_MEDIA_GET_URL = "/cgi-bin/media/get/jssdk";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMenuService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpMenuService.java
@@ -12,9 +12,9 @@ import me.chanjar.weixin.common.error.WxErrorException;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 public interface WxCpMenuService {
-  String MENU_CREATE = "https://qyapi.weixin.qq.com/cgi-bin/menu/create?agentid=%d";
-  String MENU_DELETE = "https://qyapi.weixin.qq.com/cgi-bin/menu/delete?agentid=%d";
-  String MENU_GET = "https://qyapi.weixin.qq.com/cgi-bin/menu/get?agentid=%d";
+  String MENU_CREATE = "/cgi-bin/menu/create?agentid=%d";
+  String MENU_DELETE = "/cgi-bin/menu/delete?agentid=%d";
+  String MENU_GET = "/cgi-bin/menu/get?agentid=%d";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOAuth2Service.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOAuth2Service.java
@@ -13,9 +13,9 @@ import me.chanjar.weixin.cp.bean.WxCpUserDetail;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 public interface WxCpOAuth2Service {
-  String URL_GET_USER_INFO = "https://qyapi.weixin.qq.com/cgi-bin/user/getuserinfo?code=%s&agentid=%d";
-  String URL_GET_USER_DETAIL = "https://qyapi.weixin.qq.com/cgi-bin/user/getuserdetail";
-  String URL_OAUTH_2_AUTHORIZE = "https://open.weixin.qq.com/connect/oauth2/authorize";
+  String URL_GET_USER_INFO = "/cgi-bin/user/getuserinfo?code=%s&agentid=%d";
+  String URL_GET_USER_DETAIL = "/cgi-bin/user/getuserdetail";
+  String URL_OAUTH_2_AUTHORIZE = "/connect/oauth2/authorize";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaService.java
@@ -16,10 +16,10 @@ import java.util.List;
  * @date 2019-04-06 10:52
  */
 public interface WxCpOaService {
-  String GET_CHECKIN_DATA = "https://qyapi.weixin.qq.com/cgi-bin/checkin/getcheckindata";
-  String GET_CHECKIN_OPTION = "https://qyapi.weixin.qq.com/cgi-bin/checkin/getcheckinoption";
-  String GET_APPROVAL_DATA = "https://qyapi.weixin.qq.com/cgi-bin/corp/getapprovaldata";
-  String GET_DIAL_RECORD = "https://qyapi.weixin.qq.com/cgi-bin/dial/get_dial_record";
+  String GET_CHECKIN_DATA = "/cgi-bin/checkin/getcheckindata";
+  String GET_CHECKIN_OPTION = "/cgi-bin/checkin/getcheckinoption";
+  String GET_APPROVAL_DATA = "/cgi-bin/corp/getapprovaldata";
+  String GET_DIAL_RECORD = "/cgi-bin/dial/get_dial_record";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
@@ -17,15 +17,15 @@ import me.chanjar.weixin.cp.config.WxCpConfigStorage;
  * @author chanjaster
  */
 public interface WxCpService {
-  String GET_JSAPI_TICKET = "https://qyapi.weixin.qq.com/cgi-bin/get_jsapi_ticket";
-  String GET_AGENT_CONFIG_TICKET = "https://qyapi.weixin.qq.com/cgi-bin/ticket/get?&type=agent_config";
-  String MESSAGE_SEND = "https://qyapi.weixin.qq.com/cgi-bin/message/send";
-  String GET_CALLBACK_IP = "https://qyapi.weixin.qq.com/cgi-bin/getcallbackip";
-  String BATCH_REPLACE_PARTY = "https://qyapi.weixin.qq.com/cgi-bin/batch/replaceparty";
-  String BATCH_REPLACE_USER = "https://qyapi.weixin.qq.com/cgi-bin/batch/replaceuser";
-  String BATCH_GET_RESULT = "https://qyapi.weixin.qq.com/cgi-bin/batch/getresult?jobid=";
-  String JSCODE_TO_SESSION_URL = "https://qyapi.weixin.qq.com/cgi-bin/miniprogram/jscode2session";
-  String GET_TOKEN = "https://qyapi.weixin.qq.com/cgi-bin/gettoken?&corpid=%s&corpsecret=%s";
+  String GET_JSAPI_TICKET = "/cgi-bin/get_jsapi_ticket";
+  String GET_AGENT_CONFIG_TICKET = "/cgi-bin/ticket/get?&type=agent_config";
+  String MESSAGE_SEND = "/cgi-bin/message/send";
+  String GET_CALLBACK_IP = "/cgi-bin/getcallbackip";
+  String BATCH_REPLACE_PARTY = "/cgi-bin/batch/replaceparty";
+  String BATCH_REPLACE_USER = "/cgi-bin/batch/replaceuser";
+  String BATCH_GET_RESULT = "/cgi-bin/batch/getresult?jobid=";
+  String JSCODE_TO_SESSION_URL = "/cgi-bin/miniprogram/jscode2session";
+  String GET_TOKEN = "/cgi-bin/gettoken?&corpid=%s&corpsecret=%s";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpTagService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpTagService.java
@@ -17,13 +17,13 @@ import java.util.List;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 public interface WxCpTagService {
-  String TAG_CREATE = "https://qyapi.weixin.qq.com/cgi-bin/tag/create";
-  String TAG_UPDATE = "https://qyapi.weixin.qq.com/cgi-bin/tag/update";
-  String TAG_DELETE = "https://qyapi.weixin.qq.com/cgi-bin/tag/delete?tagid=%s";
-  String TAG_LIST = "https://qyapi.weixin.qq.com/cgi-bin/tag/list";
-  String TAG_GET = "https://qyapi.weixin.qq.com/cgi-bin/tag/get?tagid=%s";
-  String TAG_ADDTAGUSERS = "https://qyapi.weixin.qq.com/cgi-bin/tag/addtagusers";
-  String TAG_DELTAGUSERS = "https://qyapi.weixin.qq.com/cgi-bin/tag/deltagusers";
+  String TAG_CREATE = "/cgi-bin/tag/create";
+  String TAG_UPDATE = "/cgi-bin/tag/update";
+  String TAG_DELETE = "/cgi-bin/tag/delete?tagid=%s";
+  String TAG_LIST = "/cgi-bin/tag/list";
+  String TAG_GET = "/cgi-bin/tag/get?tagid=%s";
+  String TAG_ADDTAGUSERS = "/cgi-bin/tag/addtagusers";
+  String TAG_DELTAGUSERS = "/cgi-bin/tag/deltagusers";
 
   /**
    * 创建标签.

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpTaskCardService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpTaskCardService.java
@@ -14,7 +14,7 @@ import java.util.List;
  * @date 2019-05-16
  */
 public interface WxCpTaskCardService {
-  String MESSAGE_UPDATE_TASKCARD = "https://qyapi.weixin.qq.com/cgi-bin/message/update_taskcard";
+  String MESSAGE_UPDATE_TASKCARD = "/cgi-bin/message/update_taskcard";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpTpService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpTpService.java
@@ -15,10 +15,10 @@ import me.chanjar.weixin.cp.config.WxCpTpConfigStorage;
  * @author zhenjun cai
  */
 public interface WxCpTpService {
-  String JSCODE_TO_SESSION_URL = "https://qyapi.weixin.qq.com/cgi-bin/service/miniprogram/jscode2session";
-  String GET_CORP_TOKEN = "https://qyapi.weixin.qq.com/cgi-bin/service/get_corp_token";
-  String GET_PERMANENT_CODE = "https://qyapi.weixin.qq.com/cgi-bin/service/get_permanent_code";
-  String GET_SUITE_TOKEN = "https://qyapi.weixin.qq.com/cgi-bin/service/get_suite_token";
+  String JSCODE_TO_SESSION_URL = "/cgi-bin/service/miniprogram/jscode2session";
+  String GET_CORP_TOKEN = "/cgi-bin/service/get_corp_token";
+  String GET_PERMANENT_CODE = "`/cgi-bin/service/get_permanent_code";
+  String GET_SUITE_TOKEN = "/cgi-bin/service/get_suite_token";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpUserService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpUserService.java
@@ -1,12 +1,12 @@
 package me.chanjar.weixin.cp.api;
 
-import java.util.List;
-import java.util.Map;
-
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.cp.bean.WxCpInviteResult;
 import me.chanjar.weixin.cp.bean.WxCpUser;
 import me.chanjar.weixin.cp.bean.WxCpUserExternalContactInfo;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * <pre>
@@ -17,18 +17,18 @@ import me.chanjar.weixin.cp.bean.WxCpUserExternalContactInfo;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 public interface WxCpUserService {
-  String URL_AUTHENTICATE = "https://qyapi.weixin.qq.com/cgi-bin/user/authsucc?userid=";
-  String URL_USER_CREATE = "https://qyapi.weixin.qq.com/cgi-bin/user/create";
-  String URL_USER_UPDATE = "https://qyapi.weixin.qq.com/cgi-bin/user/update";
-  String URL_USER_DELETE = "https://qyapi.weixin.qq.com/cgi-bin/user/delete?userid=";
-  String URL_USER_BATCH_DELETE = "https://qyapi.weixin.qq.com/cgi-bin/user/batchdelete";
-  String URL_USER_GET = "https://qyapi.weixin.qq.com/cgi-bin/user/get?userid=";
-  String URL_USER_LIST = "https://qyapi.weixin.qq.com/cgi-bin/user/list?department_id=";
-  String URL_USER_SIMPLE_LIST = "https://qyapi.weixin.qq.com/cgi-bin/user/simplelist?department_id=";
-  String URL_BATCH_INVITE = "https://qyapi.weixin.qq.com/cgi-bin/batch/invite";
-  String URL_CONVERT_TO_OPENID = "https://qyapi.weixin.qq.com/cgi-bin/user/convert_to_openid";
-  String URL_CONVERT_TO_USERID = "https://qyapi.weixin.qq.com/cgi-bin/user/convert_to_userid";
-  String URL_GET_EXTERNAL_CONTACT = "https://qyapi.weixin.qq.com/cgi-bin/crm/get_external_contact?external_userid=";
+  String URL_AUTHENTICATE = "/cgi-bin/user/authsucc?userid=";
+  String URL_USER_CREATE = "/cgi-bin/user/create";
+  String URL_USER_UPDATE = "/cgi-bin/user/update";
+  String URL_USER_DELETE = "/cgi-bin/user/delete?userid=";
+  String URL_USER_BATCH_DELETE = "/cgi-bin/user/batchdelete";
+  String URL_USER_GET = "/cgi-bin/user/get?userid=";
+  String URL_USER_LIST = "/cgi-bin/user/list?department_id=";
+  String URL_USER_SIMPLE_LIST = "/cgi-bin/user/simplelist?department_id=";
+  String URL_BATCH_INVITE = "/cgi-bin/batch/invite";
+  String URL_CONVERT_TO_OPENID = "/cgi-bin/user/convert_to_openid";
+  String URL_CONVERT_TO_USERID = "/cgi-bin/user/convert_to_userid";
+  String URL_GET_EXTERNAL_CONTACT = "/cgi-bin/crm/get_external_contact?external_userid=";
 
   /**
    * <pre>

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/BaseWxCpTpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/BaseWxCpTpServiceImpl.java
@@ -98,7 +98,7 @@ public abstract class BaseWxCpTpServiceImpl<H, P> implements WxCpTpService, Requ
     params.put("js_code", jsCode);
     params.put("grant_type", "authorization_code");
 
-    String result = this.get(JSCODE_TO_SESSION_URL, Joiner.on("&").withKeyValueSeparator("=").join(params));
+    String result = this.get(configStorage.getApiUrl(JSCODE_TO_SESSION_URL), Joiner.on("&").withKeyValueSeparator("=").join(params));
     return WxCpMaJsCode2SessionResult.fromJson(result);
   }
 
@@ -108,7 +108,7 @@ public abstract class BaseWxCpTpServiceImpl<H, P> implements WxCpTpService, Requ
 	JsonObject jsonObject = new JsonObject();
 	jsonObject.addProperty("auth_corpid", authCorpid);
 	jsonObject.addProperty("permanent_code", permanentCode);
-	String result = post(GET_CORP_TOKEN, jsonObject.toString());
+	String result = post(configStorage.getApiUrl(GET_CORP_TOKEN), jsonObject.toString());
 	
 	return WxAccessToken.fromJson(result);
   }
@@ -119,7 +119,7 @@ public abstract class BaseWxCpTpServiceImpl<H, P> implements WxCpTpService, Requ
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("auth_code", authCode);
 
-    String result = post(GET_PERMANENT_CODE, jsonObject.toString());
+    String result = post(configStorage.getApiUrl(GET_PERMANENT_CODE), jsonObject.toString());
     jsonObject = new JsonParser().parse(result).getAsJsonObject();
     WxCpTpCorp wxCpTpCorp = WxCpTpCorp.fromJson(jsonObject.get("auth_corp_info").getAsString());
     wxCpTpCorp.setPermanentCode(jsonObject.get("permanent_code").getAsString());

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImpl.java
@@ -1,17 +1,16 @@
 package me.chanjar.weixin.cp.api.impl;
 
-import java.util.List;
-
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
-
 import me.chanjar.weixin.common.error.WxError;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.cp.api.WxCpAgentService;
 import me.chanjar.weixin.cp.api.WxCpService;
 import me.chanjar.weixin.cp.bean.WxCpAgent;
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.List;
 
 
 /**
@@ -37,13 +36,14 @@ public class WxCpAgentServiceImpl implements WxCpAgentService {
       throw new IllegalArgumentException("缺少agentid参数");
     }
 
-    String responseContent = this.mainService.get(String.format(WxCpAgentService.GET_AGENT, agentId), null);
+    String responseContent = this.mainService.get(String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpAgentService.GET_AGENT), agentId), null);
     return WxCpAgent.fromJson(responseContent);
   }
 
   @Override
   public void set(WxCpAgent agentInfo) throws WxErrorException {
-    String responseContent = this.mainService.post(WxCpAgentService.AGENT_SET, agentInfo.toJson());
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpAgentService.AGENT_SET);
+    String responseContent = this.mainService.post(url, agentInfo.toJson());
     JsonObject jsonObject = JSON_PARSER.parse(responseContent).getAsJsonObject();
     if (jsonObject.get("errcode").getAsInt() != 0) {
       throw new WxErrorException(WxError.fromJson(responseContent));
@@ -52,7 +52,8 @@ public class WxCpAgentServiceImpl implements WxCpAgentService {
 
   @Override
   public List<WxCpAgent> list() throws WxErrorException {
-    String responseContent = this.mainService.get(WxCpAgentService.AGENT_LIST, null);
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpAgentService.AGENT_LIST);
+    String responseContent = this.mainService.get(url, null);
     JsonObject jsonObject = JSON_PARSER.parse(responseContent).getAsJsonObject();
     if (jsonObject.get("errcode").getAsInt() != 0) {
       throw new WxErrorException(WxError.fromJson(responseContent));

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpChatServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpChatServiceImpl.java
@@ -47,7 +47,7 @@ public class WxCpChatServiceImpl implements WxCpChatService {
     if (StringUtils.isNotBlank(chatId)) {
       data.put("chatid", chatId);
     }
-    String result = this.cpService.post(APPCHAT_CREATE, WxGsonBuilder.create().toJson(data));
+    String result = this.cpService.post(this.cpService.getWxCpConfigStorage().getApiUrl(APPCHAT_CREATE), WxGsonBuilder.create().toJson(data));
     return new JsonParser().parse(result).getAsJsonObject().get("chatid").getAsString();
   }
 
@@ -76,7 +76,7 @@ public class WxCpChatServiceImpl implements WxCpChatService {
       data.put("del_user_list", usersToDelete);
     }
 
-    this.cpService.post(APPCHAT_UPDATE, WxGsonBuilder.create().toJson(data));
+    this.cpService.post(this.cpService.getWxCpConfigStorage().getApiUrl(APPCHAT_UPDATE), WxGsonBuilder.create().toJson(data));
   }
 
   @Override
@@ -86,7 +86,7 @@ public class WxCpChatServiceImpl implements WxCpChatService {
 
   @Override
   public WxCpChat chatGet(String chatId) throws WxErrorException {
-    String result = this.cpService.get(APPCHAT_GET_CHATID + chatId, null);
+    String result = this.cpService.get(this.cpService.getWxCpConfigStorage().getApiUrl(APPCHAT_GET_CHATID + chatId), null);
     return WxCpGsonBuilder.create()
       .fromJson(JSON_PARSER.parse(result).getAsJsonObject().getAsJsonObject("chat_info").toString(), WxCpChat.class);
   }
@@ -98,7 +98,7 @@ public class WxCpChatServiceImpl implements WxCpChatService {
 
   @Override
   public void sendMsg(WxCpAppChatMessage message) throws WxErrorException {
-    this.cpService.post(WxCpChatService.APPCHAT_SEND, message.toJson());
+    this.cpService.post(this.cpService.getWxCpConfigStorage().getApiUrl(WxCpChatService.APPCHAT_SEND), message.toJson());
   }
 
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpDepartmentServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpDepartmentServiceImpl.java
@@ -1,7 +1,5 @@
 package me.chanjar.weixin.cp.api.impl;
 
-import java.util.List;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
@@ -11,6 +9,8 @@ import me.chanjar.weixin.cp.api.WxCpDepartmentService;
 import me.chanjar.weixin.cp.api.WxCpService;
 import me.chanjar.weixin.cp.bean.WxCpDepart;
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.List;
 
 /**
  * <pre>
@@ -29,25 +29,27 @@ public class WxCpDepartmentServiceImpl implements WxCpDepartmentService {
 
   @Override
   public Long create(WxCpDepart depart) throws WxErrorException {
-    String responseContent = this.mainService.post(WxCpDepartmentService.DEPARTMENT_CREATE, depart.toJson());
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpDepartmentService.DEPARTMENT_CREATE);
+    String responseContent = this.mainService.post(url, depart.toJson());
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return GsonHelper.getAsLong(tmpJsonElement.getAsJsonObject().get("id"));
   }
 
   @Override
   public void update(WxCpDepart group) throws WxErrorException {
-    this.mainService.post(WxCpDepartmentService.DEPARTMENT_UPDATE, group.toJson());
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpDepartmentService.DEPARTMENT_UPDATE);
+    this.mainService.post(url, group.toJson());
   }
 
   @Override
   public void delete(Long departId) throws WxErrorException {
-    String url = String.format(WxCpDepartmentService.DEPARTMENT_DELETE, departId);
+    String url = String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpDepartmentService.DEPARTMENT_DELETE), departId);
     this.mainService.get(url, null);
   }
 
   @Override
   public List<WxCpDepart> list(Long id) throws WxErrorException {
-    String url = WxCpDepartmentService.DEPARTMENT_LIST;
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpDepartmentService.DEPARTMENT_LIST);
     if (id != null) {
       url += "?id=" + id;
     }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpMediaServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpMediaServiceImpl.java
@@ -1,17 +1,18 @@
 package me.chanjar.weixin.cp.api.impl;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.UUID;
-
 import me.chanjar.weixin.common.bean.result.WxMediaUploadResult;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.util.fs.FileUtils;
 import me.chanjar.weixin.common.util.http.BaseMediaDownloadRequestExecutor;
 import me.chanjar.weixin.common.util.http.MediaUploadRequestExecutor;
+import me.chanjar.weixin.cp.WxCpConsts;
 import me.chanjar.weixin.cp.api.WxCpMediaService;
 import me.chanjar.weixin.cp.api.WxCpService;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
 
 /**
  * <pre>
@@ -37,7 +38,7 @@ public class WxCpMediaServiceImpl implements WxCpMediaService {
   @Override
   public WxMediaUploadResult upload(String mediaType, File file) throws WxErrorException {
     return this.mainService.execute(MediaUploadRequestExecutor.create(this.mainService.getRequestHttp()),
-      MEDIA_UPLOAD_URL + mediaType, file);
+      this.mainService.getWxCpConfigStorage().getApiUrl(MEDIA_UPLOAD_URL + mediaType), file);
   }
 
   @Override
@@ -45,7 +46,7 @@ public class WxCpMediaServiceImpl implements WxCpMediaService {
     return this.mainService.execute(
       BaseMediaDownloadRequestExecutor.create(this.mainService.getRequestHttp(),
         this.mainService.getWxCpConfigStorage().getTmpDirFile()),
-      MEDIA_GET_URL, "media_id=" + mediaId);
+      this.mainService.getWxCpConfigStorage().getApiUrl(MEDIA_GET_URL), "media_id=" + mediaId);
   }
 
   @Override
@@ -53,13 +54,13 @@ public class WxCpMediaServiceImpl implements WxCpMediaService {
     return this.mainService.execute(
       BaseMediaDownloadRequestExecutor.create(this.mainService.getRequestHttp(),
         this.mainService.getWxCpConfigStorage().getTmpDirFile()),
-      JSSDK_MEDIA_GET_URL, "media_id=" + mediaId);
+      this.mainService.getWxCpConfigStorage().getApiUrl(JSSDK_MEDIA_GET_URL), "media_id=" + mediaId);
   }
 
   @Override
   public String uploadImg(File file) throws WxErrorException {
     final WxMediaUploadResult result = this.mainService
-      .execute(MediaUploadRequestExecutor.create(this.mainService.getRequestHttp()), IMG_UPLOAD_URL, file);
+      .execute(MediaUploadRequestExecutor.create(this.mainService.getRequestHttp()), this.mainService.getWxCpConfigStorage().getApiUrl(IMG_UPLOAD_URL), file);
     return result.getUrl();
   }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpMenuServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpMenuServiceImpl.java
@@ -2,6 +2,7 @@ package me.chanjar.weixin.cp.api.impl;
 
 import me.chanjar.weixin.common.bean.menu.WxMenu;
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.WxCpConsts;
 import me.chanjar.weixin.cp.api.WxCpMenuService;
 import me.chanjar.weixin.cp.api.WxCpService;
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
@@ -28,7 +29,8 @@ public class WxCpMenuServiceImpl implements WxCpMenuService {
 
   @Override
   public void create(Integer agentId, WxMenu menu) throws WxErrorException {
-    this.mainService.post(String.format(WxCpMenuService.MENU_CREATE, agentId), menu.toJson());
+    String url = String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpMenuService.MENU_CREATE), agentId);
+    this.mainService.post(url, menu.toJson());
   }
 
   @Override
@@ -38,7 +40,7 @@ public class WxCpMenuServiceImpl implements WxCpMenuService {
 
   @Override
   public void delete(Integer agentId) throws WxErrorException {
-    String url = String.format(WxCpMenuService.MENU_DELETE, agentId);
+    String url = String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpMenuService.MENU_DELETE), agentId);
     this.mainService.get(url, null);
   }
 
@@ -49,7 +51,7 @@ public class WxCpMenuServiceImpl implements WxCpMenuService {
 
   @Override
   public WxMenu get(Integer agentId) throws WxErrorException {
-    String url = String.format(WxCpMenuService.MENU_GET, agentId);
+    String url = String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpMenuService.MENU_GET), agentId);
     try {
       String resultContent = this.mainService.get(url, null);
       return WxCpGsonBuilder.create().fromJson(resultContent, WxMenu.class);

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOAuth2ServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOAuth2ServiceImpl.java
@@ -44,7 +44,7 @@ public class WxCpOAuth2ServiceImpl implements WxCpOAuth2Service {
 
   @Override
   public String buildAuthorizationUrl(String redirectUri, String state, String scope) {
-    StringBuilder url = new StringBuilder(WxCpOAuth2Service.URL_OAUTH_2_AUTHORIZE);
+    StringBuilder url = new StringBuilder(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpOAuth2Service.URL_OAUTH_2_AUTHORIZE));
     url.append("?appid=").append(this.mainService.getWxCpConfigStorage().getCorpId());
     url.append("&redirect_uri=").append(URIUtil.encodeURIComponent(redirectUri));
     url.append("&response_type=code");
@@ -69,7 +69,7 @@ public class WxCpOAuth2ServiceImpl implements WxCpOAuth2Service {
 
   @Override
   public WxCpOauth2UserInfo getUserInfo(Integer agentId, String code) throws WxErrorException {
-    String responseText = this.mainService.get(String.format(WxCpOAuth2Service.URL_GET_USER_INFO, code, agentId), null);
+    String responseText = this.mainService.get(String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpOAuth2Service.URL_GET_USER_INFO), code, agentId), null);
     JsonElement je = new JsonParser().parse(responseText);
     JsonObject jo = je.getAsJsonObject();
 
@@ -86,7 +86,7 @@ public class WxCpOAuth2ServiceImpl implements WxCpOAuth2Service {
   public WxCpUserDetail getUserDetail(String userTicket) throws WxErrorException {
     JsonObject param = new JsonObject();
     param.addProperty("user_ticket", userTicket);
-    String responseText = this.mainService.post(WxCpOAuth2Service.URL_GET_USER_DETAIL, param.toString());
+    String responseText = this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpOAuth2Service.URL_GET_USER_DETAIL), param.toString());
     return WxCpGsonBuilder.create().fromJson(responseText, WxCpUserDetail.class);
   }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaServiceImpl.java
@@ -59,7 +59,7 @@ public class WxCpOaServiceImpl implements WxCpOaService {
 
     jsonObject.add("useridlist", jsonArray);
 
-    String responseContent = this.mainService.post(WxCpOaService.GET_CHECKIN_DATA, jsonObject.toString());
+    String responseContent = this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpOaService.GET_CHECKIN_DATA), jsonObject.toString());
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return WxCpGsonBuilder.create()
       .fromJson(
@@ -88,7 +88,7 @@ public class WxCpOaServiceImpl implements WxCpOaService {
     jsonObject.addProperty("datetime", datetime.getTime() / 1000L);
     jsonObject.add("useridlist", jsonArray);
 
-    String responseContent = this.mainService.post(WxCpOaService.GET_CHECKIN_OPTION, jsonObject.toString());
+    String responseContent = this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpOaService.GET_CHECKIN_OPTION), jsonObject.toString());
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
 
     return WxCpGsonBuilder.create()
@@ -108,7 +108,7 @@ public class WxCpOaServiceImpl implements WxCpOaService {
       jsonObject.addProperty("next_spnum", nextSpnum);
     }
 
-    String responseContent = this.mainService.post(WxCpOaService.GET_APPROVAL_DATA, jsonObject.toString());
+    String responseContent = this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpOaService.GET_APPROVAL_DATA), jsonObject.toString());
     return WxCpGsonBuilder.create().fromJson(responseContent, WxCpApprovalDataResult.class);
   }
 
@@ -140,7 +140,7 @@ public class WxCpOaServiceImpl implements WxCpOaService {
       jsonObject.addProperty("end_time", endtimestamp);
     }
 
-    String responseContent = this.mainService.post(WxCpOaService.GET_DIAL_RECORD, jsonObject.toString());
+    String responseContent = this.mainService.post(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpOaService.GET_DIAL_RECORD), jsonObject.toString());
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
 
     return WxCpGsonBuilder.create()

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceApacheHttpClientImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceApacheHttpClientImpl.java
@@ -48,7 +48,8 @@ public class WxCpServiceApacheHttpClientImpl extends BaseWxCpServiceImpl<Closeab
     }
 
     synchronized (this.globalAccessTokenRefreshLock) {
-      String url = String.format(WxCpService.GET_TOKEN, this.configStorage.getCorpId(), this.configStorage.getCorpSecret());
+      String url = String.format(this.configStorage.getApiUrl(WxCpService.GET_TOKEN), this.configStorage.getCorpId(), this.configStorage.getCorpSecret());
+
       try {
         HttpGet httpGet = new HttpGet(url);
         if (this.httpProxy != null) {

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceJoddHttpImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceJoddHttpImpl.java
@@ -1,6 +1,10 @@
 package me.chanjar.weixin.cp.api.impl;
 
-import jodd.http.*;
+import jodd.http.HttpConnectionProvider;
+import jodd.http.HttpRequest;
+import jodd.http.HttpResponse;
+import jodd.http.JoddHttp;
+import jodd.http.ProxyInfo;
 import me.chanjar.weixin.common.WxType;
 import me.chanjar.weixin.common.bean.WxAccessToken;
 import me.chanjar.weixin.common.error.WxError;
@@ -39,7 +43,7 @@ public class WxCpServiceJoddHttpImpl extends BaseWxCpServiceImpl<HttpConnectionP
     }
 
     synchronized (this.globalAccessTokenRefreshLock) {
-      HttpRequest request = HttpRequest.get(String.format(WxCpService.GET_TOKEN, this.configStorage.getCorpId(), this.configStorage.getCorpSecret()));
+      HttpRequest request = HttpRequest.get(String.format(this.configStorage.getApiUrl(WxCpService.GET_TOKEN), this.configStorage.getCorpId(), this.configStorage.getCorpSecret()));
       if (this.httpProxy != null) {
         httpClient.useProxy(this.httpProxy);
       }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceOkHttpImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpServiceOkHttpImpl.java
@@ -8,7 +8,12 @@ import me.chanjar.weixin.common.util.http.HttpType;
 import me.chanjar.weixin.common.util.http.okhttp.OkHttpProxyInfo;
 import me.chanjar.weixin.cp.api.WxCpService;
 import me.chanjar.weixin.cp.config.WxCpConfigStorage;
-import okhttp3.*;
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
 
 import java.io.IOException;
 
@@ -45,7 +50,7 @@ public class WxCpServiceOkHttpImpl extends BaseWxCpServiceImpl<OkHttpClient, OkH
       OkHttpClient client = getRequestHttpClient();
       //请求的request
       Request request = new Request.Builder()
-        .url(String.format(WxCpService.GET_TOKEN, this.configStorage.getCorpId(), this.configStorage.getCorpSecret()))
+        .url(String.format(this.configStorage.getApiUrl(WxCpService.GET_TOKEN), this.configStorage.getCorpId(), this.configStorage.getCorpSecret()))
         .get()
         .build();
       String resultContent = null;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpTagServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpTagServiceImpl.java
@@ -1,6 +1,10 @@
 package me.chanjar.weixin.cp.api.impl;
 
-import com.google.gson.*;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.cp.api.WxCpService;
@@ -32,27 +36,31 @@ public class WxCpTagServiceImpl implements WxCpTagService {
   public String create(String tagName) throws WxErrorException {
     JsonObject o = new JsonObject();
     o.addProperty("tagname", tagName);
-    String responseContent = this.mainService.post(WxCpTagService.TAG_CREATE, o.toString());
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_CREATE);
+    String responseContent = this.mainService.post(url, o.toString());
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return tmpJsonElement.getAsJsonObject().get("tagid").getAsString();
   }
 
   @Override
   public void update(String tagId, String tagName) throws WxErrorException {
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_UPDATE);
     JsonObject o = new JsonObject();
     o.addProperty("tagid", tagId);
     o.addProperty("tagname", tagName);
-    this.mainService.post(WxCpTagService.TAG_UPDATE, o.toString());
+    this.mainService.post(url, o.toString());
   }
 
   @Override
   public void delete(String tagId) throws WxErrorException {
-    this.mainService.get(String.format(WxCpTagService.TAG_DELETE, tagId), null);
+    String url = String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_DELETE), tagId);
+    this.mainService.get(url, null);
   }
 
   @Override
   public List<WxCpTag> listAll() throws WxErrorException {
-    String responseContent = this.mainService.get(WxCpTagService.TAG_LIST, null);
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_LIST);
+    String responseContent = this.mainService.get(url, null);
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return WxCpGsonBuilder.create()
       .fromJson(
@@ -64,7 +72,8 @@ public class WxCpTagServiceImpl implements WxCpTagService {
 
   @Override
   public List<WxCpUser> listUsersByTagId(String tagId) throws WxErrorException {
-    String responseContent = this.mainService.get(String.format(WxCpTagService.TAG_GET, tagId), null);
+    String url = String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_GET), tagId);
+    String responseContent = this.mainService.get(url, null);
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return WxCpGsonBuilder.create()
       .fromJson(
@@ -76,20 +85,22 @@ public class WxCpTagServiceImpl implements WxCpTagService {
 
   @Override
   public WxCpTagAddOrRemoveUsersResult addUsers2Tag(String tagId, List<String> userIds, List<String> partyIds) throws WxErrorException {
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_ADDTAGUSERS);
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("tagid", tagId);
     this.addUserIdsAndPartyIdsToJson(userIds, partyIds, jsonObject);
 
-    return WxCpTagAddOrRemoveUsersResult.fromJson(this.mainService.post(WxCpTagService.TAG_ADDTAGUSERS, jsonObject.toString()));
+    return WxCpTagAddOrRemoveUsersResult.fromJson(this.mainService.post(url, jsonObject.toString()));
   }
 
   @Override
   public WxCpTagAddOrRemoveUsersResult removeUsersFromTag(String tagId, List<String> userIds, List<String> partyIds) throws WxErrorException {
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_DELTAGUSERS);
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("tagid", tagId);
     this.addUserIdsAndPartyIdsToJson(userIds, partyIds, jsonObject);
 
-    return WxCpTagAddOrRemoveUsersResult.fromJson(this.mainService.post(WxCpTagService.TAG_DELTAGUSERS, jsonObject.toString()));
+    return WxCpTagAddOrRemoveUsersResult.fromJson(this.mainService.post(url, jsonObject.toString()));
   }
 
   private void addUserIdsAndPartyIdsToJson(List<String> userIds, List<String> partyIds, JsonObject jsonObject) {
@@ -116,7 +127,8 @@ public class WxCpTagServiceImpl implements WxCpTagService {
       throw new IllegalArgumentException("缺少tagId参数");
     }
 
-    String responseContent = this.mainService.get(String.format(WxCpTagService.TAG_GET, tagId), null);
+    String url = String.format(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_GET), tagId);
+    String responseContent = this.mainService.get(url, null);
     return WxCpTagGetResult.fromJson(responseContent);
   }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpTaskCardServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpTaskCardServiceImpl.java
@@ -3,6 +3,7 @@ package me.chanjar.weixin.cp.api.impl;
 import lombok.RequiredArgsConstructor;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.util.json.WxGsonBuilder;
+import me.chanjar.weixin.cp.WxCpConsts;
 import me.chanjar.weixin.cp.api.WxCpService;
 import me.chanjar.weixin.cp.api.WxCpTaskCardService;
 
@@ -33,6 +34,7 @@ public class WxCpTaskCardServiceImpl implements WxCpTaskCardService {
     data.put("task_id", taskId);
     data.put("clicked_key", clickedKey);
 
-    this.mainService.post(MESSAGE_UPDATE_TASKCARD, WxGsonBuilder.create().toJson(data));
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(MESSAGE_UPDATE_TASKCARD);
+    this.mainService.post(url, WxGsonBuilder.create().toJson(data));
   }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpTpServiceApacheHttpClientImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpTpServiceApacheHttpClientImpl.java
@@ -52,7 +52,7 @@ public class WxCpTpServiceApacheHttpClientImpl extends BaseWxCpTpServiceImpl<Clo
 
     synchronized (this.globalSuiteAccessTokenRefreshLock) {
       try {
-        HttpPost httpPost = new HttpPost(WxCpTpService.GET_SUITE_TOKEN);
+        HttpPost httpPost = new HttpPost(configStorage.getApiUrl(WxCpTpService.GET_SUITE_TOKEN));
         if (this.httpProxy != null) {
           RequestConfig config = RequestConfig.custom()
             .setProxy(this.httpProxy).build();

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpUserServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpUserServiceImpl.java
@@ -1,8 +1,5 @@
 package me.chanjar.weixin.cp.api.impl;
 
-import java.util.List;
-import java.util.Map;
-
 import com.google.common.collect.Maps;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -11,12 +8,16 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.reflect.TypeToken;
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.WxCpConsts;
 import me.chanjar.weixin.cp.api.WxCpService;
 import me.chanjar.weixin.cp.api.WxCpUserService;
 import me.chanjar.weixin.cp.bean.WxCpInviteResult;
 import me.chanjar.weixin.cp.bean.WxCpUser;
 import me.chanjar.weixin.cp.bean.WxCpUserExternalContactInfo;
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * <pre>
@@ -34,23 +35,26 @@ public class WxCpUserServiceImpl implements WxCpUserService {
 
   @Override
   public void authenticate(String userId) throws WxErrorException {
-    this.mainService.get(WxCpUserService.URL_AUTHENTICATE + userId, null);
+    this.mainService.get(this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_AUTHENTICATE + userId), null);
   }
 
   @Override
   public void create(WxCpUser user) throws WxErrorException {
-    this.mainService.post(WxCpUserService.URL_USER_CREATE, user.toJson());
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_USER_CREATE);
+    this.mainService.post(url, user.toJson());
   }
 
   @Override
   public void update(WxCpUser user) throws WxErrorException {
-    this.mainService.post(WxCpUserService.URL_USER_UPDATE, user.toJson());
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_USER_UPDATE);
+    this.mainService.post(url, user.toJson());
   }
 
   @Override
   public void delete(String... userIds) throws WxErrorException {
     if (userIds.length == 1) {
-      this.mainService.get(WxCpUserService.URL_USER_DELETE + userIds[0], null);
+      String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_USER_DELETE + userIds[0]);
+      this.mainService.get(url, null);
       return;
     }
 
@@ -66,7 +70,8 @@ public class WxCpUserServiceImpl implements WxCpUserService {
 
   @Override
   public WxCpUser getById(String userid) throws WxErrorException {
-    String responseContent = this.mainService.get(WxCpUserService.URL_USER_GET + userid, null);
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_USER_GET + userid);
+    String responseContent = this.mainService.get(url, null);
     return WxCpUser.fromJson(responseContent);
   }
 
@@ -82,7 +87,8 @@ public class WxCpUserServiceImpl implements WxCpUserService {
       params += "&status=0";
     }
 
-    String responseContent = this.mainService.get(WxCpUserService.URL_USER_LIST + departId, params);
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_USER_LIST + departId);
+    String responseContent = this.mainService.get(url, params);
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return WxCpGsonBuilder.create()
       .fromJson(tmpJsonElement.getAsJsonObject().get("userlist"),
@@ -103,7 +109,8 @@ public class WxCpUserServiceImpl implements WxCpUserService {
       params += "&status=0";
     }
 
-    String responseContent = this.mainService.get(WxCpUserService.URL_USER_SIMPLE_LIST + departId, params);
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_USER_SIMPLE_LIST + departId);
+    String responseContent = this.mainService.get(url, params);
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return WxCpGsonBuilder.create()
       .fromJson(
@@ -140,18 +147,20 @@ public class WxCpUserServiceImpl implements WxCpUserService {
       jsonObject.add("tag", jsonArray);
     }
 
-    return WxCpInviteResult.fromJson(this.mainService.post(WxCpUserService.URL_BATCH_INVITE, jsonObject.toString()));
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_BATCH_INVITE);
+    return WxCpInviteResult.fromJson(this.mainService.post(url, jsonObject.toString()));
   }
 
   @Override
   public Map<String, String> userId2Openid(String userId, Integer agentId) throws WxErrorException {
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_CONVERT_TO_OPENID);
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("userid", userId);
     if (agentId != null) {
       jsonObject.addProperty("agentid", agentId);
     }
 
-    String responseContent = this.mainService.post(WxCpUserService.URL_CONVERT_TO_OPENID, jsonObject.toString());
+    String responseContent = this.mainService.post(url, jsonObject.toString());
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     Map<String, String> result = Maps.newHashMap();
     if (tmpJsonElement.getAsJsonObject().get("openid") != null) {
@@ -169,14 +178,16 @@ public class WxCpUserServiceImpl implements WxCpUserService {
   public String openid2UserId(String openid) throws WxErrorException {
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("openid", openid);
-    String responseContent = this.mainService.post(WxCpUserService.URL_CONVERT_TO_USERID, jsonObject.toString());
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_CONVERT_TO_USERID);
+    String responseContent = this.mainService.post(url, jsonObject.toString());
     JsonElement tmpJsonElement = new JsonParser().parse(responseContent);
     return tmpJsonElement.getAsJsonObject().get("userid").getAsString();
   }
 
   @Override
   public WxCpUserExternalContactInfo getExternalContact(String userId) throws WxErrorException {
-    String responseContent = this.mainService.get(WxCpUserService.URL_GET_EXTERNAL_CONTACT + userId, null);
+    String url = this.mainService.getWxCpConfigStorage().getApiUrl(WxCpUserService.URL_GET_EXTERNAL_CONTACT + userId);
+    String responseContent = this.mainService.get(url, null);
     return WxCpUserExternalContactInfo.fromJson(responseContent);
   }
 }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpConfigStorage.java
@@ -12,6 +12,22 @@ import java.io.File;
  */
 public interface WxCpConfigStorage {
 
+  /**
+   * 设置企业微信服务器 baseUrl.
+   *
+   * 默认值是 https://qyapi.weixin.qq.com , 如果使用默认值，则不需要调用 setBaseApiUrl
+   *
+   * @param baseUrl 企业微信服务器 Url
+   */
+  void setBaseApiUrl(String baseUrl);
+
+  /**
+   * 读取企业微信 API Url.
+   *
+   * 支持私有化企业微信服务器.
+   */
+  String getApiUrl(String path);
+
   String getAccessToken();
 
   boolean isAccessTokenExpired();

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpInMemoryConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpInMemoryConfigStorage.java
@@ -39,6 +39,21 @@ public class WxCpInMemoryConfigStorage implements WxCpConfigStorage {
 
   private volatile ApacheHttpClientBuilder apacheHttpClientBuilder;
 
+  protected volatile String baseApiUrl;
+
+  @Override
+  public void setBaseApiUrl(String baseUrl) {
+    this.baseApiUrl = baseUrl;
+  }
+
+  @Override
+  public String getApiUrl(String path) {
+    if (baseApiUrl == null) {
+      baseApiUrl = "https://qyapi.weixin.qq.com";
+    }
+    return baseApiUrl;
+  }
+
   @Override
   public String getAccessToken() {
     return this.accessToken;

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpJedisConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpJedisConfigStorage.java
@@ -38,6 +38,21 @@ public class WxCpJedisConfigStorage implements WxCpConfigStorage {
   private volatile File tmpDirFile;
   private volatile ApacheHttpClientBuilder apacheHttpClientBuilder;
 
+  protected volatile String baseApiUrl;
+
+  @Override
+  public void setBaseApiUrl(String baseUrl) {
+    this.baseApiUrl = baseUrl;
+  }
+
+  @Override
+  public String getApiUrl(String path) {
+    if (baseApiUrl == null) {
+      baseApiUrl = "https://qyapi.weixin.qq.com";
+    }
+    return baseApiUrl;
+  }
+
   public WxCpJedisConfigStorage(JedisPool jedisPool) {
     this.jedisPool = jedisPool;
   }

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpTpConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpTpConfigStorage.java
@@ -12,6 +12,22 @@ import java.io.File;
  */
 public interface WxCpTpConfigStorage {
 
+  /**
+   * 设置企业微信服务器 baseUrl.
+   *
+   * 默认值是 https://qyapi.weixin.qq.com , 如果使用默认值，则不需要调用 setBaseApiUrl
+   *
+   * @param baseUrl 企业微信服务器 Url
+   */
+  void setBaseApiUrl(String baseUrl);
+
+  /**
+   * 读取企业微信 API Url.
+   *
+   * 支持私有化企业微信服务器.
+   */
+  String getApiUrl(String path);
+
   String getSuiteAccessToken();
 
   boolean isSuiteAccessTokenExpired();

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpTpInMemoryConfigStorage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/WxCpTpInMemoryConfigStorage.java
@@ -38,6 +38,21 @@ public class WxCpTpInMemoryConfigStorage implements WxCpTpConfigStorage {
 
   private volatile ApacheHttpClientBuilder apacheHttpClientBuilder;
 
+  protected volatile String baseApiUrl;
+
+  @Override
+  public void setBaseApiUrl(String baseUrl) {
+    this.baseApiUrl = baseUrl;
+  }
+
+  @Override
+  public String getApiUrl(String path) {
+    if (baseApiUrl == null) {
+      baseApiUrl = "https://qyapi.weixin.qq.com";
+    }
+    return baseApiUrl;
+  }
+
   @Override
   public String getSuiteAccessToken() {
     return this.suiteAccessToken;

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpAgentServiceImplTest.java
@@ -2,6 +2,7 @@ package me.chanjar.weixin.cp.api.impl;
 
 import com.google.inject.Inject;
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.WxCpConsts;
 import me.chanjar.weixin.cp.api.ApiTestModule;
 import me.chanjar.weixin.cp.api.WxCpAgentService;
 import me.chanjar.weixin.cp.api.WxCpService;
@@ -14,7 +15,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
 
 
 /**
@@ -70,7 +70,7 @@ public class WxCpAgentServiceImplTest {
     @Test
     public void testGet() throws Exception {
       String returnJson = "{\"errcode\": 0,\"errmsg\": \"ok\",\"agentid\": 9,\"name\": \"测试应用\",\"square_logo_url\": \"http://wx.qlogo.cn/mmhead/alksjf;lasdjf;lasjfuodiuj3rj2o34j/0\",\"description\": \"这是一个企业号应用\",\"allow_userinfos\": {\"user\": [{\"userid\": \"0009854\"}, {\"userid\": \"1723\"}, {\"userid\": \"5625\"}]},\"allow_partys\": {\"partyid\": [42762742]},\"allow_tags\": {\"tagid\": [23, 22, 35, 19, 32, 125, 133, 46, 150, 38, 183, 9, 7]},\"close\": 0,\"redirect_domain\": \"weixin.com.cn\",\"report_location_flag\": 0,\"isreportenter\": 0,\"home_url\": \"\"}";
-      when(wxService.get(String.format(WxCpAgentService.GET_AGENT, 9), null)).thenReturn(returnJson);
+      when(wxService.get(String.format(wxService.getWxCpConfigStorage().getApiUrl(WxCpAgentService.GET_AGENT), 9), null)).thenReturn(returnJson);
       when(wxService.getAgentService()).thenReturn(new WxCpAgentServiceImpl(wxService));
 
       WxCpAgentService wxAgentService = this.wxService.getAgentService();

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpTagServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpTagServiceImplTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 /**
@@ -83,7 +82,7 @@ public class WxCpTagServiceImplTest {
   public void testGet() throws WxErrorException {
     String apiResultJson = "{\"errcode\": 0,\"errmsg\": \"ok\",\"userlist\": [{\"userid\": \"0124035\",\"name\": \"王五\"},{\"userid\": \"0114035\",\"name\": \"梦雪\"}],\"partylist\": [9576,9567,9566],\"tagname\": \"测试标签-001\"}";
     WxCpService wxService = mock(WxCpService.class);
-    when(wxService.get(String.format(WxCpTagService.TAG_GET, 150), null)).thenReturn(apiResultJson);
+    when(wxService.get(String.format(wxService.getWxCpConfigStorage().getApiUrl(WxCpTagService.TAG_GET), 150), null)).thenReturn(apiResultJson);
     when(wxService.getTagService()).thenReturn(new WxCpTagServiceImpl(wxService));
 
     WxCpTagService wxCpTagService = wxService.getTagService();


### PR DESCRIPTION
项目中有接触到客户部署了私有化部署的企业微信，而WxJava中服务地址 https://qyapi.weixin.qq.com 是固定写死的，导致无法使用WxJava。

产品说明见：https://work.weixin.qq.com/server

为此，对项目做了修改，供您参考。

使用方法：

通过 wxCpConfigStorage.setBaseApiUrl("http://local_server:port"); 设置私有化部署的企业微信服务地址.

默认值是 https://qyapi.weixin.qq.com , 如果使用默认值，则不需要调用 setBaseApiUrl(baseUrl).