### PR TITLE
修复微信红包查询签名错误

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayRedpackQueryRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayRedpackQueryRequest.java
@@ -27,7 +27,7 @@ public class WxPayRedpackQueryRequest extends BaseWxPayRequest {
 
   @Override
   protected String[] getIgnoredParamsForSign() {
-    return new String[]{"sub_appid","sub_mch_id"};
+    return new String[]{"sub_appid","sub_mch_id","sign_type"};
   }
   /**
    * 商户订单号


### PR DESCRIPTION
少过滤 sign_type 参数