### PR TITLE
解决微信通讯录回调 新增成员 编辑成员 xml解析出错的bug

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/xml/XStreamCDataIntegerArrayConverter.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/xml/XStreamCDataIntegerArrayConverter.java
@@ -1,0 +1,37 @@
+package me.chanjar.weixin.common.util.xml;
+
+import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
+
+/**
+ * @author Pwenlee
+ * @date 2019/9/18 10:20
+ * @description
+ */
+public class XStreamCDataIntegerArrayConverter extends AbstractSingleValueConverter {
+
+    @Override
+    public boolean canConvert(Class clazz) {
+      return clazz == Integer[].class;
+    }
+
+    @Override
+    public String toString(Object obj) {
+      return "<![CDATA[" + super.toString(obj) + "]]>";
+    }
+
+    @Override
+    public Object fromString(String s) {
+      if(null != s){
+        String[] strings = s.split(",");
+        if(null != strings){
+          int length = strings.length;
+          Integer[] integers = new Integer[length];
+          for (int i = 0; i < length; i++){
+            integers[i] = Integer.valueOf(strings[i]);
+          }
+          return integers;
+        }
+      }
+      return new Integer[0];
+    }
+}

--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/xml/XStreamCDataLongArrayConverter.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/xml/XStreamCDataLongArrayConverter.java
@@ -1,0 +1,37 @@
+package me.chanjar.weixin.common.util.xml;
+
+import com.thoughtworks.xstream.converters.basic.AbstractSingleValueConverter;
+
+/**
+ * @author Pwenlee
+ * @date 2019/9/18 10:20
+ * @description
+ */
+public class XStreamCDataLongArrayConverter extends AbstractSingleValueConverter {
+
+    @Override
+    public boolean canConvert(Class clazz) {
+      return clazz == Long[].class;
+    }
+
+    @Override
+    public String toString(Object obj) {
+      return "<![CDATA[" + super.toString(obj) + "]]>";
+    }
+
+    @Override
+    public Object fromString(String s) {
+      if(null != s){
+        String[] strings = s.split(",");
+        if(null != strings){
+          int length = strings.length;
+          Long[] longs = new Long[length];
+          for (int i = 0; i < length; i++){
+            longs[i] = Long.valueOf(strings[i]);
+          }
+          return longs;
+        }
+      }
+      return new Long[0];
+    }
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpXmlMessage.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/WxCpXmlMessage.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import me.chanjar.weixin.common.api.WxConsts;
 import me.chanjar.weixin.common.util.XmlUtils;
 import me.chanjar.weixin.common.util.xml.XStreamCDataConverter;
+import me.chanjar.weixin.common.util.xml.XStreamCDataIntegerArrayConverter;
+import me.chanjar.weixin.common.util.xml.XStreamCDataLongArrayConverter;
 import me.chanjar.weixin.cp.config.WxCpConfigStorage;
 import me.chanjar.weixin.cp.util.crypto.WxCpCryptUtil;
 import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
@@ -214,7 +216,7 @@ public class WxCpXmlMessage implements Serializable {
    * 成员部门列表，变更时推送，仅返回该应用有查看权限的部门id.
    */
   @XStreamAlias("Department")
-  @XStreamConverter(value = XStreamCDataConverter.class)
+  @XStreamConverter(value = XStreamCDataLongArrayConverter.class)
   private Long[] departments;
 
   /**
@@ -268,6 +270,7 @@ public class WxCpXmlMessage implements Serializable {
    * 表示所在部门是否为上级，0-否，1-是，顺序与Department字段的部门逐一对应.
    */
   @XStreamAlias("IsLeaderInDept")
+  @XStreamConverter(value = XStreamCDataIntegerArrayConverter.class)
   private Integer[] isLeaderInDept;
 
   /**


### PR DESCRIPTION
新增成员 编辑成员 企业微信回调时如果xml里面包含了<Departments>标签 就会xml解析出错 
因为WxCpXmlMessage把departments定义成了Long[] 但是xstream转换器没有定义