### PR TITLE
:bug: 修正下载对账单接口中错误代码“NO Bill Exist”字符串与实际不一致问题

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/constant/WxPayErrorCode.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/constant/WxPayErrorCode.java
@@ -459,9 +459,10 @@ public class WxPayErrorCode {
      * 描述：账单不存在.
      * 原因：当前商户号没有已成交的订单，不生成对账单
      * 解决方案：请检查当前商户号在指定日期内是否有成功的交易。
+     * 错误：微信官方文档这个错误的字符串显示是'NO Bill Exist'('o'是大写)，实际返回是'No Bill Exist'('o'是小写）
      * </pre>
      */
-    public static final String NO_Bill_Exist = "NO Bill Exist";
+    public static final String NO_Bill_Exist = "No Bill Exist";
 
     /**
      * <pre>


### PR DESCRIPTION
微信支付官方文档显示的也是"NO Bill Exist"，但实际响应这个错误是"No Bill Exist"。
![image](https://user-images.githubusercontent.com/10743446/66907598-2c183a00-f03c-11e9-8c3c-a2390c967ab1.png)
实际错误字符串：
![image](https://user-images.githubusercontent.com/10743446/66907774-73062f80-f03c-11e9-92aa-d79600e00aa2.png)
