### PR TITLE
fix 微信开放平台获取授权列表异常

### DIFF
--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
@@ -22,7 +22,7 @@ public interface WxOpenComponentService {
   String API_GET_AUTHORIZER_INFO_URL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_info";
   String API_GET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_option";
   String API_SET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/api_set_authorizer_option";
-  String API_GET_AUTHORIZER_LIST = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_list?component_access_token=%s";
+  String API_GET_AUTHORIZER_LIST = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_list";
 
   String COMPONENT_LOGIN_PAGE_URL = "https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s&auth_type=xxx&biz_appid=xxx";
 

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
@@ -36,7 +36,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
   private static final Map<String, WxOpenMaService> WX_OPEN_MA_SERVICE_MAP = new ConcurrentHashMap<>();
   private static final Map<String, WxMpService> WX_OPEN_MP_SERVICE_MAP = new ConcurrentHashMap<>();
   private static final Map<String, WxOpenFastMaService> WX_OPEN_FAST_MA_SERVICE_MAP = new ConcurrentHashMap<>();
-
+  private static final int MAX_RETRY = 5;
   protected final Logger log = LoggerFactory.getLogger(this.getClass());
   private WxOpenService wxOpenService;
 
@@ -135,7 +135,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
     String componentAccessToken = getComponentAccessToken(false);
     String uriWithComponentAccessToken = uri + (uri.contains("?") ? "&" : "?") + accessTokenKey + "=" + componentAccessToken;
     try {
-    	if(retryCount>=5) {
+    	if(retryCount>=MAX_RETRY) {
 			throw new WxErrorException(
 					WxError.builder().errorCode(40000).errorMsg("重试多次仍失败").errorMsgEn("请确认请求参数无误").build());
 		}
@@ -429,14 +429,14 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
   public void addToTemplate(long draftId) throws WxErrorException {
     JsonObject param = new JsonObject();
     param.addProperty("draft_id", draftId);
-    post(ADD_TO_TEMPLATE_URL, param.toString(), "access_token");
+    post(ADD_TO_TEMPLATE_URL, param.toString(), "access_token",0);
   }
 
   @Override
   public void deleteTemplate(long templateId) throws WxErrorException {
     JsonObject param = new JsonObject();
     param.addProperty("template_id", templateId);
-    post(DELETE_TEMPLATE_URL, param.toString(), "access_token");
+    post(DELETE_TEMPLATE_URL, param.toString(), "access_token",0);
   }
 
   @Override
@@ -444,7 +444,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
     JsonObject param = new JsonObject();
     param.addProperty("appid", appId);
 
-    String json = post(CREATE_OPEN_URL, param.toString(), "access_token");
+    String json = post(CREATE_OPEN_URL, param.toString(), "access_token",0);
 
     return WxOpenCreateResult.fromJson(json);
   }
@@ -458,7 +458,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
     jsonObject.addProperty("legal_persona_wechat", legalPersonaWechat);
     jsonObject.addProperty("legal_persona_name", legalPersonaName);
     jsonObject.addProperty("component_phone", componentPhone);
-    String response = post(FAST_REGISTER_WEAPP_URL, jsonObject.toString (), "component_access_token");
+    String response = post(FAST_REGISTER_WEAPP_URL, jsonObject.toString (), "component_access_token",0);
     return WxOpenGsonBuilder.create ().fromJson (response, WxOpenResult.class);
   }
 
@@ -468,7 +468,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
     jsonObject.addProperty("name",name);
     jsonObject.addProperty("legal_persona_wechat", legalPersonaWechat);
     jsonObject.addProperty("legal_persona_name", legalPersonaName);
-    String response = post(FAST_REGISTER_WEAPP_SEARCH_URL, jsonObject.toString (), "component_access_token");
+    String response = post(FAST_REGISTER_WEAPP_SEARCH_URL, jsonObject.toString (), "component_access_token",0);
     return WxOpenGsonBuilder.create ().fromJson (response, WxOpenResult.class);
   }
 }

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
@@ -303,16 +303,13 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
 
   @Override
   public WxOpenAuthorizerListResult getAuthorizerList(int begin, int len) throws WxErrorException {
-
-    String url = String.format(API_GET_AUTHORIZER_LIST, getComponentAccessToken(false));
     begin = begin < 0 ? 0 : begin;
     len = len == 0 ? 10 : len;
-
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("component_appid", getWxOpenConfigStorage().getComponentAppId());
     jsonObject.addProperty("offset", begin);
     jsonObject.addProperty("count", len);
-    String responseContent = post(url, jsonObject.toString());
+    String responseContent = post(API_GET_AUTHORIZER_LIST, jsonObject.toString());
     WxOpenAuthorizerListResult ret = WxOpenGsonBuilder.create().fromJson(responseContent, WxOpenAuthorizerListResult.class);
     if(ret != null && ret.getList() != null){
       for(Map<String, String> data : ret.getList()){


### PR DESCRIPTION
WxOpenComponentServiceImpl#getAuthorizerList由post内部维护token，否则总是使用旧token导致死循环