### PR TITLE
fix 微信开放平台获取授权列表异常

### DIFF
--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
@@ -22,7 +22,7 @@ public interface WxOpenComponentService {
   String API_GET_AUTHORIZER_INFO_URL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_info";
   String API_GET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_option";
   String API_SET_AUTHORIZER_OPTION_URL = "https://api.weixin.qq.com/cgi-bin/component/api_set_authorizer_option";
-  String API_GET_AUTHORIZER_LIST = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_list?component_access_token=%s";
+  String API_GET_AUTHORIZER_LIST = "https://api.weixin.qq.com/cgi-bin/component/api_get_authorizer_list";
 
   String COMPONENT_LOGIN_PAGE_URL = "https://mp.weixin.qq.com/cgi-bin/componentloginpage?component_appid=%s&pre_auth_code=%s&redirect_uri=%s&auth_type=xxx&biz_appid=xxx";
 

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
@@ -303,16 +303,13 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
 
   @Override
   public WxOpenAuthorizerListResult getAuthorizerList(int begin, int len) throws WxErrorException {
-
-    String url = String.format(API_GET_AUTHORIZER_LIST, getComponentAccessToken(false));
     begin = begin < 0 ? 0 : begin;
     len = len == 0 ? 10 : len;
-
     JsonObject jsonObject = new JsonObject();
     jsonObject.addProperty("component_appid", getWxOpenConfigStorage().getComponentAppId());
     jsonObject.addProperty("offset", begin);
     jsonObject.addProperty("count", len);
-    String responseContent = post(url, jsonObject.toString());
+    String responseContent = post(API_GET_AUTHORIZER_LIST, jsonObject.toString());
     WxOpenAuthorizerListResult ret = WxOpenGsonBuilder.create().fromJson(responseContent, WxOpenAuthorizerListResult.class);
     if(ret != null && ret.getList() != null){
       for(Map<String, String> data : ret.getList()){


### PR DESCRIPTION
WxOpenComponentServiceImpl#getAuthorizerList由post内部维护token，否则总是使用旧token导致死循环