### PR TITLE
修复创建成员同时回调create_user和update_user事件判断成重复的BUG

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/message/WxCpMessageRouter.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/message/WxCpMessageRouter.java
@@ -219,8 +219,11 @@ public class WxCpMessageRouter {
       messageId.append("-").append(wxMessage.getUserId());
     }
 
-    return this.messageDuplicateChecker.isDuplicate(messageId.toString());
+    if (StringUtils.isNotEmpty(wxMessage.getChangeType())) {
+      messageId.append("-").append(wxMessage.getChangeType());
+    }
 
+    return this.messageDuplicateChecker.isDuplicate(messageId.toString());
   }
 
   /**


### PR DESCRIPTION
企业微信新建成员时会同时回调create_user和update_user事件，按照现在的规则会被判断成重复消息

加入ChangeType防止同一时间不同事件被判断成重复