### PR TITLE
bugFix,微信卡券签名生成错误

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpCardServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpCardServiceImpl.java
@@ -81,6 +81,7 @@ public class WxMpCardServiceImpl implements WxMpCardService {
     signParams[optionalSignParam.length + 1] = nonceStr;
     signParams[optionalSignParam.length + 2] = cardApiTicket;
     StringBuilder sb = new StringBuilder();
+    Arrays.sort(signParams);
     for (String a : signParams) {
       sb.append(a);
     }


### PR DESCRIPTION
错误描述:微信卡券签名生成错误
文档地址:https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/JS-SDK.html#65
文档说明:签名说明#1,参数字符串的应先按照字典序排序,再进行sha1加密