### PR TITLE
Feature: make WxMpMaterialNewsArticle to be Serializable

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/material/WxMpMaterialNews.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/material/WxMpMaterialNews.java
@@ -62,6 +62,8 @@ public class WxMpMaterialNews implements Serializable {
    */
   @Data
   public static class WxMpMaterialNewsArticle implements Serializable{
+
+    private static final long serialVersionUID = -635384661692321171L;
     /**
      * (必填) 图文消息缩略图的media_id，可以在基础支持-上传多媒体文件接口中获得.
      */

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/material/WxMpMaterialNews.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/bean/material/WxMpMaterialNews.java
@@ -61,7 +61,7 @@ public class WxMpMaterialNews implements Serializable {
    * @author chanjarster
    */
   @Data
-  public static class WxMpMaterialNewsArticle {
+  public static class WxMpMaterialNewsArticle implements Serializable{
     /**
      * (必填) 图文消息缩略图的media_id，可以在基础支持-上传多媒体文件接口中获得.
      */


### PR DESCRIPTION
微信公众平台-获取图文永久素材接口有调用限制,需要缓存调用结果存入redis, 所以结果对象需要可序列化