### PR TITLE
修复微信支付查询分账结果一直报签名失败的问题

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/ProfitSharingQueryRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/ProfitSharingQueryRequest.java
@@ -51,4 +51,9 @@ public class ProfitSharingQueryRequest extends BaseWxPayRequest {
   protected void checkConstraints() throws WxPayException {
     this.setSignType(WxPayConstants.SignType.HMAC_SHA256);
   }
+
+  @Override
+  public boolean ignoreAppid() {
+    return true;
+  }
 }

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/ProfitSharingServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/ProfitSharingServiceImpl.java
@@ -76,7 +76,6 @@ public class ProfitSharingServiceImpl implements ProfitSharingService {
 
   @Override
   public ProfitSharingQueryResult profitSharingQuery(ProfitSharingQueryRequest request) throws WxPayException {
-    if (true) throw new WxPayException("暂不支持，微信一直返回签名失败");
     request.checkAndSign(this.payService.getConfig());
     String url = this.payService.getPayBaseUrl() + "/pay/profitsharingquery";
 


### PR DESCRIPTION
签名失败原因: 微信支付查询分账结果接口不需要传appid参数,签名时需进行忽略