### PR TITLE
添加 WxPayService.createOrder 返回交易类型对应实体类方法

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/constant/WxPayConstants.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/constant/WxPayConstants.java
@@ -1,5 +1,10 @@
 package com.github.binarywang.wxpay.constant;
 
+import com.github.binarywang.wxpay.bean.order.WxPayAppOrderResult;
+import com.github.binarywang.wxpay.bean.order.WxPayMpOrderResult;
+import com.github.binarywang.wxpay.bean.order.WxPayMwebOrderResult;
+import com.github.binarywang.wxpay.bean.order.WxPayNativeOrderResult;
+import com.github.binarywang.wxpay.bean.result.WxPayMicropayResult;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.time.FastDateFormat;
 
@@ -103,6 +108,52 @@ public class WxPayConstants {
      * 刷卡支付有单独的支付接口，不调用统一下单接口
      */
     public static final String MICROPAY = "MICROPAY";
+
+    @SuppressWarnings("unused")
+    public abstract static class Specific<R> {
+
+      public abstract String getType();
+
+      public static Specific<WxPayNativeOrderResult> NATIVE =
+        new Specific<WxPayNativeOrderResult>() {
+          @Override
+          public String getType() {
+            return TradeType.NATIVE;
+          }
+        };
+
+      public static Specific<WxPayAppOrderResult> APP =
+        new Specific<WxPayAppOrderResult>() {
+          @Override
+          public String getType() {
+            return TradeType.APP;
+          }
+        };
+
+      public static Specific<WxPayMpOrderResult> JSAPI =
+        new Specific<WxPayMpOrderResult>() {
+          @Override
+          public String getType() {
+            return TradeType.JSAPI;
+          }
+        };
+
+      public static Specific<WxPayMwebOrderResult> MWEB =
+        new Specific<WxPayMwebOrderResult>() {
+          @Override
+          public String getType() {
+            return TradeType.MWEB;
+          }
+        };
+
+      public static Specific<WxPayMicropayResult> MICROPAY =
+        new Specific<WxPayMicropayResult>() {
+          @Override
+          public String getType() {
+            return TradeType.MICROPAY;
+          }
+        };
+    }
   }
 
   /**

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/constant/WxPayConstants.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/constant/WxPayConstants.java
@@ -114,6 +114,9 @@ public class WxPayConstants {
 
       public abstract String getType();
 
+      private Specific() {
+      }
+
       public static Specific<WxPayNativeOrderResult> NATIVE =
         new Specific<WxPayNativeOrderResult>() {
           @Override

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/WxPayService.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/WxPayService.java
@@ -8,6 +8,7 @@ import com.github.binarywang.wxpay.bean.notify.WxScanPayNotifyResult;
 import com.github.binarywang.wxpay.bean.request.*;
 import com.github.binarywang.wxpay.bean.result.*;
 import com.github.binarywang.wxpay.config.WxPayConfig;
+import com.github.binarywang.wxpay.constant.WxPayConstants;
 import com.github.binarywang.wxpay.exception.WxPayException;
 
 import java.io.File;
@@ -165,6 +166,17 @@ public interface WxPayService {
    * @throws WxPayException the wx pay exception
    */
   <T> T createOrder(WxPayUnifiedOrderRequest request) throws WxPayException;
+
+  /**
+   * 调用统一下单接口，并组装生成支付所需参数对象.
+   *
+   * @see WxPayService#createOrder(WxPayUnifiedOrderRequest)
+   * @param specificTradeType 将使用的交易方式，不能为 null
+   * @param request 统一下单请求参数，设定的 tradeType 及配置里的 tradeType 将被忽略，转而使用 specificTradeType
+   * @return 返回 {@link WxPayConstants.TradeType.Specific} 指定的类
+   * @throws WxPayException the wx pay exception
+   */
+  <T> T createOrder(WxPayConstants.TradeType.Specific<T> specificTradeType, WxPayUnifiedOrderRequest request) throws WxPayException;
 
   /**
    * 统一下单(详见https://pay.weixin.qq.com/wiki/doc/api/app/app.php?chapter=9_1)

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImpl.java
@@ -352,6 +352,15 @@ public abstract class BaseWxPayServiceImpl implements WxPayService {
   }
 
   @Override
+  public <T> T createOrder(TradeType.Specific<T> specificTradeType, WxPayUnifiedOrderRequest request) throws WxPayException {
+    if (specificTradeType == null) {
+      throw new IllegalArgumentException("specificTradeType 不能为 null");
+    }
+    request.setTradeType(specificTradeType.getType());
+    return createOrder(request);
+  }
+
+  @Override
   public WxPayUnifiedOrderResult unifiedOrder(WxPayUnifiedOrderRequest request) throws WxPayException {
     request.checkAndSign(this.getConfig());
 

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImplTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImplTest.java
@@ -144,6 +144,24 @@ public class BaseWxPayServiceImplTest {
     log.warn(this.payService.getWxApiData().toString());
   }
 
+  @Test
+  public void testCreateOrderSpecific() throws Exception {
+    // Won't compile
+    // WxPayMpOrderResult result = payService.createOrder(TradeType.Specific.APP, new WxPayUnifiedOrderRequest());
+    payService.createOrder(
+      TradeType.Specific.JSAPI,
+      WxPayUnifiedOrderRequest.newBuilder()
+        .body("我去")
+        .totalFee(1)
+        .productId("aaa")
+        .spbillCreateIp("11.1.11.1")
+        .notifyUrl("111111")
+        .outTradeNo("111111290")
+        .build()
+    )
+      .getAppId();
+  }
+
   /**
    * Test get pay info.
    *


### PR DESCRIPTION
调用 `WxPayService` 的 [`<T> T createOrder(WxPayUnifiedOrderRequest request)`](https://github.com/Wechat-Group/WxJava/blob/7bd4726e9cf60d662a20f82597a38dadb5cc84d5/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/WxPayService.java#L167) 时，经常找源码来看返回什么样的实体类，再强制转换。

通常在业务中使用此方法时，可以明确交易类型，所以添加一个交易类型的类，设置交易类型的同时，顺便作为确定 `createOrder` 返回类型的参数传入。