### PR TITLE
更新默认connectionRequestTimeout

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/apache/DefaultApacheHttpClientBuilder.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/http/apache/DefaultApacheHttpClientBuilder.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class DefaultApacheHttpClientBuilder implements ApacheHttpClientBuilder {
   protected final Logger log = LoggerFactory.getLogger(DefaultApacheHttpClientBuilder.class);
   private final AtomicBoolean prepared = new AtomicBoolean(false);
-  private int connectionRequestTimeout = 3000;
+  private int connectionRequestTimeout = -1;
   private int connectionTimeout = 5000;
   private int soTimeout = 5000;
   private int idleConnTimeout = 60000;


### PR DESCRIPTION
从连接池获取连接时不应该设置默认超时时间，实测多线程同时进行Http请求时会出错（比如业务需要同时推送大量模板消息时会使用多线程发送，实测30线程同时推送2000条模板消息约有10%因为获取不到连接报org.apache.http.conn.ConnectionPoolTimeoutException异常导致消息发送失败），参考：https://www.jianshu.com/p/48f5f57e9920