### PR TITLE
微信开放平台,新增使用userstr参数解绑体验者的接口

### DIFF
--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMaService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMaService.java
@@ -296,6 +296,14 @@ public interface WxOpenMaService extends WxMaService {
   WxOpenResult unbindTester(String wechatid) throws WxErrorException;
 
   /**
+   * 解除绑定小程序体验者，其他平台绑定的体验者无法获取到wechatid，可用此方法解绑，详见文档
+   * https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/Mini_Programs/unbind_tester.html
+   *
+   * @param userstr 人员对应的唯一字符串， 可通过获取已绑定的体验者列表获取人员对应的字符串
+   */
+  WxOpenResult unbindTesterByUserstr(String userstr) throws WxErrorException;
+
+  /**
    * 获得体验者列表
    */
   WxOpenMaTesterListResult getTesterList() throws WxErrorException;

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMaServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMaServiceImpl.java
@@ -195,6 +195,20 @@ public class WxOpenMaServiceImpl extends WxMaServiceImpl implements WxOpenMaServ
   }
 
   /**
+   * 解除绑定小程序体验者
+   * @param userstr 人员对应的唯一字符串， 可通过获取已绑定的体验者列表获取人员对应的字符串
+   * @return
+   * @throws WxErrorException
+   */
+  @Override
+  public WxOpenResult unbindTesterByUserstr(String userstr) throws WxErrorException {
+    JsonObject paramJson = new JsonObject();
+    paramJson.addProperty("userstr", userstr);
+    String response = post(API_UNBIND_TESTER, GSON.toJson(paramJson));
+    return WxMaGsonBuilder.create().fromJson(response, WxOpenResult.class);
+  }
+
+  /**
    * 获得体验者列表
    *
    * @return


### PR DESCRIPTION
微信开放平台 ,解绑小程序体验者 ,若是在其他平台绑定的体验者无法获取到wechatid，所以只能使用userstr参数进行解绑,此处补充了这种方式.[详见文档](https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/Mini_Programs/unbind_tester.html)