### PR TITLE
hotfix: 小程序二维码创建参数包含中文出现乱码

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/util/QrcodeRequestExecutor.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/util/QrcodeRequestExecutor.java
@@ -48,7 +48,7 @@ public class QrcodeRequestExecutor implements RequestExecutor<File, AbstractWxMa
       );
     }
 
-    httpPost.setEntity(new StringEntity(qrcodeWrapper.toJson()));
+    httpPost.setEntity(new StringEntity(qrcodeWrapper.toJson(), ContentType.APPLICATION_JSON));
 
     try (final CloseableHttpResponse response = requestHttp.getRequestHttpClient().execute(httpPost);
          final InputStream inputStream = InputStreamResponseHandler.INSTANCE.handleResponse(response)) {


### PR DESCRIPTION
小程序二维码创建过程中，如果path参数中包含中文，需要将content-type改为utf-8