### PR TITLE
增加商户处理微信支付或退款回调后同步返回给微信参数的生成方法，通过格式化字符串返回xml字符串结果，避免进行xml对象的转换。

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayNotifyResponse.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/WxPayNotifyResponse.java
@@ -60,4 +60,31 @@ public class WxPayNotifyResponse {
     return xstream.toXML(response).replace("\n", "").replace("  ", "");
   }
 
+  /**
+   * Fail string.
+   *
+   * @param msg the msg
+   * @return the string
+   */
+  public static String failResp(String msg) {
+    return generateXml(FAIL, msg);
+  }
+
+  /**
+   * Success string.
+   *
+   * @param msg the msg
+   * @return the string
+   */
+  public static String successResp(String msg) {
+    return generateXml(SUCCESS, msg);
+  }
+
+
+  /**
+   * 使用格式化字符串生成xml字符串
+   */
+  private static String generateXml(String code, String msg) {
+    return String.format("<xml><return_code><![CDATA[%s]]></return_code><return_msg><![CDATA[%s]]></return_msg></xml>", code, msg);
+  }
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/notify/WxPayNotifyResponseTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/notify/WxPayNotifyResponseTest.java
@@ -20,4 +20,22 @@ public class WxPayNotifyResponseTest {
       "<return_msg><![CDATA[OK]]></return_msg>" +
       "</xml>");
   }
+
+  @Test
+  public void testSuccessResp() {
+    final String result = WxPayNotifyResponse.successResp("OK");
+    assertThat(result).isEqualTo("<xml>" +
+      "<return_code><![CDATA[SUCCESS]]></return_code>" +
+      "<return_msg><![CDATA[OK]]></return_msg>" +
+      "</xml>");
+  }
+
+  @Test
+  public void testFailResp() {
+    final String result = WxPayNotifyResponse.failResp("500");
+    assertThat(result).isEqualTo("<xml>" +
+      "<return_code><![CDATA[FAIL]]></return_code>" +
+      "<return_msg><![CDATA[500]]></return_msg>" +
+      "</xml>");
+  }
 }


### PR DESCRIPTION
增加微信支付或退款回调的时候返回xml字符串方法