### PR TITLE
修复无法切换到初始公众号配置的问题并完善了removeConfigStorage

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
@@ -414,7 +414,7 @@ public abstract class BaseWxMpServiceImpl<H, P> implements WxMpService, RequestH
 
   @Override
   public void setWxMpConfigStorage(WxMpConfigStorage wxConfigProvider) {
-    final String defaultMpId = WxMpConfigStorageHolder.get();
+    final String defaultMpId = wxConfigProvider.getAppId();
     this.setMultiConfigStorages(ImmutableMap.of(defaultMpId, wxConfigProvider), defaultMpId);
   }
 

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
@@ -440,6 +440,18 @@ public abstract class BaseWxMpServiceImpl<H, P> implements WxMpService, RequestH
   @Override
   public void removeConfigStorage(String mpId) {
     synchronized (this) {
+      if (this.configStorageMap.size() == 1) {
+        this.configStorageMap.remove(mpId);
+        log.warn("已删除最后一个公众号配置：{}，须立即使用setWxMpConfigStorage或setMultiConfigStorages添加配置", mpId);
+        return;
+      }
+      if (WxMpConfigStorageHolder.get().equals(mpId)) {
+        this.configStorageMap.remove(mpId);
+        final String defaultMpId = this.configStorageMap.keySet().iterator().next();
+        WxMpConfigStorageHolder.set(defaultMpId);
+        log.warn("已删除默认公众号配置，公众号【{}】被设为默认配置", defaultMpId);
+        return;
+      }
       this.configStorageMap.remove(mpId);
     }
   }

--- a/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
+++ b/weixin-java-mp/src/test/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImplTest.java
@@ -41,6 +41,7 @@ public class BaseWxMpServiceImplTest {
     assertTrue(this.wxService.switchover("another"));
     assertThat(WxMpConfigStorageHolder.get()).isEqualTo("another");
     assertFalse(this.wxService.switchover("whatever"));
+    assertFalse(this.wxService.switchover("default"));
   }
 
   @Test


### PR DESCRIPTION
### 简要描述

- __使用springboot配置的单公众号工程，mpId=111，通过addConfigStorage添加新配置mpId=222，然后switchoverTo(222)转换到新配置，再切换回来switchoverTo(111)抛异常。__
- __调用removeConfigStorage删除配置时，如果删除了唯一配置或默认配置将导致异常。__

### 模块版本情况
* WxJava 模块名: weixin-java-mp
* WxJava 版本号:3.8.0

### 详细描述

- __调用setWxMpConfigStorage方法进行初始化配置时，尚无默认配置存于WxMpConfigStorageHolder中，所以get方法取到的只是默认值“default”而不是传入的mpId，再经过setMultiConfigStorages把“default”配置回WxMpConfigStorageHolder，导致出错。__
```
public void setWxMpConfigStorage(WxMpConfigStorage wxConfigProvider) {
    final String defaultMpId = WxMpConfigStorageHolder.get();
    this.setMultiConfigStorages(ImmutableMap.of(defaultMpId, wxConfigProvider), defaultMpId);
  }
```

- __针对第二个问题添加了判断，根据情况打出warn日志。__



