### PR TITLE
FIX bug:SDK 扫码登录签名算法 获取 Ticket时，type参数必须是2

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/enums/TicketType.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/enums/TicketType.java
@@ -21,7 +21,7 @@ public enum TicketType {
   /**
    * sdk
    */
-  SDK("sdk"),
+  SDK("2"),
   /**
    * 微信卡券
    */


### PR DESCRIPTION
https://api.weixin.qq.com/cgi-bin/ticket/getticket?access_token=ACCESS_TOKEN&type=2
3.8.0 版本 getTicket()方法的出错 