### PR TITLE
公众平台send_ignore_reprint参数默认为0,修改默认和公众号接口一致

### DIFF
--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpMassOpenIdsMessageGsonAdapter.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/util/json/WxMpMassOpenIdsMessageGsonAdapter.java
@@ -48,7 +48,7 @@ public class WxMpMassOpenIdsMessageGsonAdapter implements JsonSerializer<WxMpMas
       messageJson.add(WxConsts.MassMsgType.MPVIDEO, sub);
     }
     messageJson.addProperty("msgtype", message.getMsgType());
-    messageJson.addProperty("send_ignore_reprint", message.isSendIgnoreReprint() ? 0 : 1);
+    messageJson.addProperty("send_ignore_reprint", message.isSendIgnoreReprint() ? 1 : 0);
 
     if(StringUtils.isNotEmpty(message.getClientMsgId())){
       messageJson.addProperty("clientmsgid", message.getClientMsgId());


### PR DESCRIPTION
开发者可以对群发接口的 send_ignore_reprint 参数进行设置，指定待群发的文章被判定为转载时，是否继续群发。
当 send_ignore_reprint 参数设置为1时，文章被判定为转载时，且原创文允许转载时，将继续进行群发操作。
当 send_ignore_reprint 参数设置为0时，文章被判定为转载时，将停止群发操作。
send_ignore_reprint 默认为0。