### PR TITLE
修复无法解析<ExtAttr><Item>....</Item></ExtAttr>这种节点数据，如：

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/XmlUtils.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/XmlUtils.java
@@ -3,10 +3,7 @@ package me.chanjar.weixin.common.util;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.Element;
-import org.dom4j.Node;
+import org.dom4j.*;
 import org.dom4j.io.SAXReader;
 import org.dom4j.tree.DefaultText;
 import org.xml.sax.SAXException;
@@ -50,14 +47,16 @@ public class XmlUtils {
   }
 
   private static Object element2MapOrString(Element element) {
-    Map<String, Object> result = Maps.newHashMap();
 
     final List<Node> content = element.content();
-    if (content.size() <= 1) {
+    final Set<String> names = names(content);
+
+    // 判断节点下有无非文本节点(非Text和CDATA)，如无，直接取Text文本内容
+    if (names.size() < 1) {
       return element.getText();
     }
 
-    final Set<String> names = names(content);
+    Map<String, Object> result = Maps.newHashMap();
     if (names.size() == 1) {
       // 说明是个列表，各个子对象是相同的name
       List<Object> list = Lists.newArrayList();
@@ -90,7 +89,8 @@ public class XmlUtils {
   private static Set<String> names(List<Node> nodes) {
     Set<String> names = Sets.newHashSet();
     for (Node node : nodes) {
-      if (node instanceof DefaultText) {
+      // 如果节点类型是Text或CDATA跳过
+      if (node instanceof DefaultText || node instanceof CDATA) {
         continue;
       }
       names.add(node.getName());


### PR DESCRIPTION
String xml = "<xml><ToUserName><![CDATA[ww3fb6dc50e568348a]]></ToUserName><FromUserName><![CDATA[sys]]></FromUserName><CreateTime>1600855248</CreateTime><MsgType><![CDATA[event]]></MsgType><Event><![CDATA[change_contact]]></Event><ChangeType><![CDATA[update_user]]></ChangeType><UserID><![CDATA[1000100010001]]></UserID><Gender>2</Gender><ExtAttr><Item><Name><![CDATA[工号]]></Name><Value><![CDATA[10007000000]]></Value><Type>0</Type><Text><Value><![CDATA[10007000000]]></Value></Text></Item></ExtAttr><Alias><![CDATA[xiaoqi]]></Alias></xml>";
修复前： ExtAttr== null
修复后：ExtAttr={Item=[{Type=0, Value=10007000000, Text={Value=[10007000000]}, Name=工号}]}