### PR TITLE
分账回退结果查询签名错误，修复忽略sub_appid

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/ProfitSharingReturnQueryRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/ProfitSharingReturnQueryRequest.java
@@ -74,7 +74,7 @@ public class ProfitSharingReturnQueryRequest extends BaseWxPayRequest {
 
   @Override
   protected boolean ignoreSubAppId() {
-    return super.ignoreSubAppId();
+    return true;
   }
 
   @Override

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/ProfitSharingReturnQueryRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/profitsharing/ProfitSharingReturnQueryRequest.java
@@ -73,6 +73,11 @@ public class ProfitSharingReturnQueryRequest extends BaseWxPayRequest {
   }
 
   @Override
+  protected boolean ignoreSubAppId() {
+    return super.ignoreSubAppId();
+  }
+
+  @Override
   protected void storeMap(Map<String, String> map) {
     map.put("order_id", orderId);
     map.put("out_order_no", outOrderNo);


### PR DESCRIPTION
分账回退解决查询接口签名错误，其他接口都正常，官方文档没有sub_appid参数，如下
https://pay.weixin.qq.com/wiki/doc/api/allocation_sl.php?chapter=25_8&index=8