### PR TITLE
添加接口:第三方平台代公众号实现复用公众号资料快速创建小程序

### DIFF
--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenComponentService.java
@@ -2,7 +2,6 @@ package me.chanjar.weixin.open.api;
 
 import cn.binarywang.wx.miniapp.bean.WxMaJscode2SessionResult;
 import me.chanjar.weixin.common.error.WxErrorException;
-import me.chanjar.weixin.mp.api.WxMpService;
 import me.chanjar.weixin.mp.bean.result.WxMpOAuth2AccessToken;
 import me.chanjar.weixin.open.bean.WxOpenCreateResult;
 import me.chanjar.weixin.open.bean.WxOpenGetResult;
@@ -133,7 +132,7 @@ public interface WxOpenComponentService {
    * @param appid the appid
    * @return the wx mp service by appid
    */
-  WxMpService getWxMpServiceByAppid(String appid);
+  WxOpenMpService getWxMpServiceByAppid(String appid);
 
   /**
    * 获取指定appid的开放平台小程序服务（继承一般小程序服务能力）.

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMpService.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/WxOpenMpService.java
@@ -1,0 +1,47 @@
+package me.chanjar.weixin.open.api;
+
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.mp.api.WxMpService;
+import me.chanjar.weixin.open.bean.mp.FastRegisterResult;
+
+/**
+ * <pre>
+ *     微信开放平台代公众号实现服务能力
+ *     https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1489144594_DhNoV&token=&lang=zh_CN
+ * </pre>
+ * <p>
+ * Created by zpf on 2020/10/15
+ */
+public interface WxOpenMpService extends WxMpService {
+
+  /**
+   * 取复用公众号快速注册小程序的授权链接.
+   */
+  String URL_FAST_REGISTER_AUTH = "https://mp.weixin.qq.com/cgi-bin/fastregisterauth?appid=%s&component_appid=%s&copy_wx_verify=%s&redirect_uri=%s";
+
+  /**
+   * 复用公众号快速注册小程序
+   */
+  String API_FAST_REGISTER = "https://api.weixin.qq.com/cgi-bin/account/fastregister";
+
+
+  /**
+   * 取复用公众号快速注册小程序的授权链接
+   * https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/Official_Accounts/fast_registration_of_mini_program.html
+   *
+   * @param redirectUri  用户扫码授权后，MP 扫码页面将跳转到该地址(注:1.链接需 urlencode 2.Host 需和第三方平台在微信开放平台上面填写的登 录授权的发起页域名一致)
+   * @param copyWxVerify 是否复用公众号的资质进行微信认证,可空,默认false
+   * @return 返回授权链接，注意：由于微信开放平台限制，此链接直接使用后端301重定向微信会报错，必须是在第三方平台所在域名的页面的html或js触发跳转才能成功
+   */
+  String getFastRegisterAuthUrl(String redirectUri, Boolean copyWxVerify);
+
+  /**
+   * 复用公众号快速注册小程序
+   * 注意：调用本接口的第三方平台必须是已经全网发布的，否则微信会报-1服务器繁忙错误，然后再报ticket无效错误，并且接口的使用次数会增加，同时还会生成一个废小程序
+   * https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/Official_Accounts/fast_registration_of_mini_program.html
+   *
+   * @param ticket 公众号扫码授权的凭证(公众平台扫码页面回跳到第三方平台时携带)
+   * @return 返回授权码, 然后请使用第三方平台的sdk获得授权, 参考: WxOpenService.getWxOpenComponentService().getQueryAuth( fastRegisterResult.getAuthorizationCode() );
+   */
+  FastRegisterResult fastRegister(String ticket) throws WxErrorException;
+}

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenComponentServiceImpl.java
@@ -36,14 +36,14 @@ import java.util.concurrent.locks.Lock;
 public class WxOpenComponentServiceImpl implements WxOpenComponentService {
 
   private static final Map<String, WxOpenMaService> WX_OPEN_MA_SERVICE_MAP = new ConcurrentHashMap<>();
-  private static final Map<String, WxMpService> WX_OPEN_MP_SERVICE_MAP = new ConcurrentHashMap<>();
+  private static final Map<String, WxOpenMpService> WX_OPEN_MP_SERVICE_MAP = new ConcurrentHashMap<>();
   private static final Map<String, WxOpenFastMaService> WX_OPEN_FAST_MA_SERVICE_MAP = new ConcurrentHashMap<>();
 
   private final WxOpenService wxOpenService;
 
   @Override
-  public WxMpService getWxMpServiceByAppid(String appId) {
-    WxMpService wxMpService = WX_OPEN_MP_SERVICE_MAP.get(appId);
+  public WxOpenMpService getWxMpServiceByAppid(String appId) {
+    WxOpenMpService wxMpService = WX_OPEN_MP_SERVICE_MAP.get(appId);
     if (wxMpService == null) {
       synchronized (WX_OPEN_MP_SERVICE_MAP) {
         wxMpService = WX_OPEN_MP_SERVICE_MAP.get(appId);
@@ -381,7 +381,7 @@ public class WxOpenComponentServiceImpl implements WxOpenComponentService {
 
       WxOpenAuthorizerAccessToken wxOpenAuthorizerAccessToken = WxOpenAuthorizerAccessToken.fromJson(responseContent);
       config.updateAuthorizerAccessToken(appId, wxOpenAuthorizerAccessToken);
-      config.updateAuthorizerRefreshToken(appId,wxOpenAuthorizerAccessToken.getAuthorizerRefreshToken());
+      config.updateAuthorizerRefreshToken(appId, wxOpenAuthorizerAccessToken.getAuthorizerRefreshToken());
       return config.getAuthorizerAccessToken(appId);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMpServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenMpServiceImpl.java
@@ -1,15 +1,21 @@
 package me.chanjar.weixin.open.api.impl;
 
+import lombok.SneakyThrows;
 import me.chanjar.weixin.common.error.WxErrorException;
-import me.chanjar.weixin.mp.config.WxMpConfigStorage;
 import me.chanjar.weixin.mp.api.impl.WxMpServiceImpl;
-import me.chanjar.weixin.mp.bean.result.WxMpOAuth2AccessToken;
+import me.chanjar.weixin.mp.config.WxMpConfigStorage;
 import me.chanjar.weixin.open.api.WxOpenComponentService;
+import me.chanjar.weixin.open.api.WxOpenMpService;
+import me.chanjar.weixin.open.bean.mp.FastRegisterResult;
+
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Objects;
 
 /**
  * @author <a href="https://github.com/007gzs">007</a>
  */
-public class WxOpenMpServiceImpl extends WxMpServiceImpl {
+public class WxOpenMpServiceImpl extends WxMpServiceImpl implements WxOpenMpService {
   private WxOpenComponentService wxOpenComponentService;
   private WxMpConfigStorage wxMpConfigStorage;
   private String appId;
@@ -31,4 +37,20 @@ public class WxOpenMpServiceImpl extends WxMpServiceImpl {
     return wxOpenComponentService.getAuthorizerAccessToken(appId, forceRefresh);
   }
 
+  @SneakyThrows
+  @Override
+  public String getFastRegisterAuthUrl(String redirectUri, Boolean copyWxVerify) {
+    String copyInfo = Objects.equals(copyWxVerify, false) ? "0" : "1";
+    String componentAppId = wxOpenComponentService.getWxOpenConfigStorage().getComponentAppId();
+    String encoded = URLEncoder.encode(redirectUri, "UTF-8");
+    return String.format(URL_FAST_REGISTER_AUTH, appId, componentAppId, copyInfo, encoded);
+  }
+
+  @Override
+  public FastRegisterResult fastRegister(String ticket) throws WxErrorException {
+    HashMap<String, String> params = new HashMap<>();
+    params.put("ticket", ticket);
+    String json = post(API_FAST_REGISTER, params);
+    return FastRegisterResult.fromJson(json);
+  }
 }

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/mp/FastRegisterResult.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/bean/mp/FastRegisterResult.java
@@ -1,0 +1,37 @@
+package me.chanjar.weixin.open.bean.mp;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import me.chanjar.weixin.common.util.json.WxGsonBuilder;
+import me.chanjar.weixin.mp.bean.result.WxMpResult;
+
+/**
+ * 复用公众号资料快速注册小程序结果
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class FastRegisterResult extends WxMpResult {
+
+  /**
+   * 小程序AppId
+   */
+  @SerializedName("appid")
+  private String appId;
+
+  /**
+   * 授权码,然后请使用第三方平台的sdk获得授权, 参考: WxOpenService.getWxOpenComponentService().getQueryAuth( this.getAuthorizationCode() );
+   */
+  @SerializedName("authorization_code")
+  private String authorizationCode;
+
+  /**
+   * 是否与公众号关联成功
+   */
+  @SerializedName("is_wx_verify_succ")
+  private Boolean isWxVerifySucc;
+
+  public static FastRegisterResult fromJson(String json) {
+    return WxGsonBuilder.create().fromJson(json, FastRegisterResult.class);
+  }
+}


### PR DESCRIPTION
### 简要描述
 如题，希望添加相关接口


### 官方文档地址
https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/Official_Accounts/fast_registration_of_mini_program.html

*注意，如果要测试此接口，请先发布第三方平台，否则微信会先报-1错误，再报ticket无效错误。*

