### PR TITLE
修复更新票据锁调用时机

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaJsapiServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaJsapiServiceImpl.java
@@ -41,11 +41,13 @@ public class WxMaJsapiServiceImpl implements WxMaJsapiService {
       Lock lock = this.wxMaService.getWxMaConfig().getCardApiTicketLock();
       lock.lock();
       try {
-        String responseContent = this.wxMaService.get(GET_JSAPI_TICKET_URL + "?type=wx_card", null);
-        JsonObject tmpJsonObject = GsonParser.parse(responseContent);
-        String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
-        int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
-        this.wxMaService.getWxMaConfig().updateCardApiTicket(jsapiTicket, expiresInSeconds);
+        if (this.wxMaService.getWxMaConfig().isCardApiTicketExpired()) {
+          String responseContent = this.wxMaService.get(GET_JSAPI_TICKET_URL + "?type=wx_card", null);
+          JsonObject tmpJsonObject = GsonParser.parse(responseContent);
+          String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
+          int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
+          this.wxMaService.getWxMaConfig().updateCardApiTicket(jsapiTicket, expiresInSeconds);
+        }
       } finally {
         lock.unlock();
       }

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaJsapiServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaJsapiServiceImpl.java
@@ -32,22 +32,23 @@ public class WxMaJsapiServiceImpl implements WxMaJsapiService {
 
   @Override
   public String getCardApiTicket(boolean forceRefresh) throws WxErrorException {
-    Lock lock = this.wxMaService.getWxMaConfig().getCardApiTicketLock();
-    lock.lock();
-    try {
-      if (forceRefresh) {
-        this.wxMaService.getWxMaConfig().expireCardApiTicket();
-      }
 
-      if (this.wxMaService.getWxMaConfig().isCardApiTicketExpired()) {
+    if (forceRefresh) {
+      this.wxMaService.getWxMaConfig().expireCardApiTicket();
+    }
+
+    if (this.wxMaService.getWxMaConfig().isCardApiTicketExpired()) {
+      Lock lock = this.wxMaService.getWxMaConfig().getCardApiTicketLock();
+      lock.lock();
+      try {
         String responseContent = this.wxMaService.get(GET_JSAPI_TICKET_URL + "?type=wx_card", null);
         JsonObject tmpJsonObject = GsonParser.parse(responseContent);
         String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
         int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
         this.wxMaService.getWxMaConfig().updateCardApiTicket(jsapiTicket, expiresInSeconds);
+      } finally {
+        lock.unlock();
       }
-    } finally {
-      lock.unlock();
     }
     return this.wxMaService.getWxMaConfig().getCardApiTicket();
   }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
@@ -151,23 +151,24 @@ public abstract class BaseWxMpServiceImpl<H, P> implements WxMpService, RequestH
 
   @Override
   public String getTicket(TicketType type, boolean forceRefresh) throws WxErrorException {
-    Lock lock = this.getWxMpConfigStorage().getTicketLock(type);
-    lock.lock();
-    try {
-      if (forceRefresh) {
-        this.getWxMpConfigStorage().expireTicket(type);
-      }
 
-      if (this.getWxMpConfigStorage().isTicketExpired(type)) {
+    if (forceRefresh) {
+      this.getWxMpConfigStorage().expireTicket(type);
+    }
+
+    if (this.getWxMpConfigStorage().isTicketExpired(type)) {
+      Lock lock = this.getWxMpConfigStorage().getTicketLock(type);
+      lock.lock();
+      try {
         String responseContent = execute(SimpleGetRequestExecutor.create(this),
           GET_TICKET_URL.getUrl(this.getWxMpConfigStorage()) + type.getCode(), null);
         JsonObject tmpJsonObject = GsonParser.parse(responseContent);
         String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
         int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
         this.getWxMpConfigStorage().updateTicket(type, jsapiTicket, expiresInSeconds);
+      } finally {
+        lock.unlock();
       }
-    } finally {
-      lock.unlock();
     }
 
     return this.getWxMpConfigStorage().getTicket(type);

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/BaseWxMpServiceImpl.java
@@ -160,12 +160,14 @@ public abstract class BaseWxMpServiceImpl<H, P> implements WxMpService, RequestH
       Lock lock = this.getWxMpConfigStorage().getTicketLock(type);
       lock.lock();
       try {
-        String responseContent = execute(SimpleGetRequestExecutor.create(this),
-          GET_TICKET_URL.getUrl(this.getWxMpConfigStorage()) + type.getCode(), null);
-        JsonObject tmpJsonObject = GsonParser.parse(responseContent);
-        String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
-        int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
-        this.getWxMpConfigStorage().updateTicket(type, jsapiTicket, expiresInSeconds);
+        if (this.getWxMpConfigStorage().isTicketExpired(type)) {
+          String responseContent = execute(SimpleGetRequestExecutor.create(this),
+            GET_TICKET_URL.getUrl(this.getWxMpConfigStorage()) + type.getCode(), null);
+          JsonObject tmpJsonObject = GsonParser.parse(responseContent);
+          String jsapiTicket = tmpJsonObject.get("ticket").getAsString();
+          int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
+          this.getWxMpConfigStorage().updateTicket(type, jsapiTicket, expiresInSeconds);
+        }
       } finally {
         lock.unlock();
       }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpCardServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpCardServiceImpl.java
@@ -48,24 +48,24 @@ public class WxMpCardServiceImpl implements WxMpCardService {
   @Override
   public String getCardApiTicket(boolean forceRefresh) throws WxErrorException {
     final TicketType type = TicketType.WX_CARD;
-    Lock lock = getWxMpService().getWxMpConfigStorage().getTicketLock(type);
-    lock.lock();
-    try {
 
-      if (forceRefresh) {
-        this.getWxMpService().getWxMpConfigStorage().expireTicket(type);
-      }
+    if (forceRefresh) {
+      this.getWxMpService().getWxMpConfigStorage().expireTicket(type);
+    }
 
-      if (this.getWxMpService().getWxMpConfigStorage().isTicketExpired(type)) {
+    if (this.getWxMpService().getWxMpConfigStorage().isTicketExpired(type)) {
+      Lock lock = getWxMpService().getWxMpConfigStorage().getTicketLock(type);
+      lock.lock();
+      try {
         String responseContent = this.wxMpService.execute(SimpleGetRequestExecutor
           .create(this.getWxMpService().getRequestHttp()), WxMpApiUrl.Card.CARD_GET_TICKET, null);
         JsonObject tmpJsonObject = GsonParser.parse(responseContent);
         String cardApiTicket = tmpJsonObject.get("ticket").getAsString();
         int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
         this.getWxMpService().getWxMpConfigStorage().updateTicket(type, cardApiTicket, expiresInSeconds);
+      } finally {
+        lock.unlock();
       }
-    } finally {
-      lock.unlock();
     }
     return this.getWxMpService().getWxMpConfigStorage().getTicket(type);
   }

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpCardServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpCardServiceImpl.java
@@ -57,12 +57,14 @@ public class WxMpCardServiceImpl implements WxMpCardService {
       Lock lock = getWxMpService().getWxMpConfigStorage().getTicketLock(type);
       lock.lock();
       try {
-        String responseContent = this.wxMpService.execute(SimpleGetRequestExecutor
-          .create(this.getWxMpService().getRequestHttp()), WxMpApiUrl.Card.CARD_GET_TICKET, null);
-        JsonObject tmpJsonObject = GsonParser.parse(responseContent);
-        String cardApiTicket = tmpJsonObject.get("ticket").getAsString();
-        int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
-        this.getWxMpService().getWxMpConfigStorage().updateTicket(type, cardApiTicket, expiresInSeconds);
+        if (this.getWxMpService().getWxMpConfigStorage().isTicketExpired(type)) {
+          String responseContent = this.wxMpService.execute(SimpleGetRequestExecutor
+            .create(this.getWxMpService().getRequestHttp()), WxMpApiUrl.Card.CARD_GET_TICKET, null);
+          JsonObject tmpJsonObject = GsonParser.parse(responseContent);
+          String cardApiTicket = tmpJsonObject.get("ticket").getAsString();
+          int expiresInSeconds = tmpJsonObject.get("expires_in").getAsInt();
+          this.getWxMpService().getWxMpConfigStorage().updateTicket(type, cardApiTicket, expiresInSeconds);
+        }
       } finally {
         lock.unlock();
       }


### PR DESCRIPTION
避免每次都加锁，只在票据过期需要更新的时候才加锁，避免并发场景照成调用异常。