### PR TITLE
Fix: 企微三方获取授权企业accesstoken过期时间错误

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/impl/AbstractWxCpTpInRedisConfigImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/impl/AbstractWxCpTpInRedisConfigImpl.java
@@ -224,7 +224,7 @@ public abstract class AbstractWxCpTpInRedisConfigImpl extends WxCpTpDefaultConfi
 
     WxAccessToken accessTokenEntity = new WxAccessToken();
     accessTokenEntity.setAccessToken(accessToken);
-    accessTokenEntity.setExpiresIn(expire.intValue());
+    accessTokenEntity.setExpiresIn(Math.max(Math.toIntExact(expire), 0));
     return accessTokenEntity;
   }
 

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/impl/AbstractWxCpTpInRedisConfigImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/config/impl/AbstractWxCpTpInRedisConfigImpl.java
@@ -224,7 +224,7 @@ public abstract class AbstractWxCpTpInRedisConfigImpl extends WxCpTpDefaultConfi
 
     WxAccessToken accessTokenEntity = new WxAccessToken();
     accessTokenEntity.setAccessToken(accessToken);
-    accessTokenEntity.setExpiresIn((int) ((expire - System.currentTimeMillis()) / 1000 + 200));
+    accessTokenEntity.setExpiresIn(expire.intValue());
     return accessTokenEntity;
   }
 


### PR DESCRIPTION
在AbstractWxCpTpInRedisConfigImpl类中，更新accessToken的方法中
<img width="1325" height="218" alt="1" src="https://github.com/user-attachments/assets/a04f838c-0a00-43bc-9a81-85993a64f814" />

使用的是凭证有效时长，单位是秒

<img width="1111" height="232" alt="3" src="https://github.com/user-attachments/assets/8dd8677e-7243-493b-95e2-7420de4cbc13" />
但是在获取时，错误的将expire当作截止时间点的shi时间戳进行了有效期时长计算，所得有效期为负值，不符合预期，因此需要做如上修改

祝好。