### PR TITLE
feat(cp/oa): add phonenumber field to ContentValue for PhoneNumber control

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/applydata/ContentValue.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/applydata/ContentValue.java
@@ -61,6 +61,20 @@ public class ContentValue implements Serializable {
   @SerializedName("bank_account")
   private BankAccount bankAccount;
 
+  @SerializedName("phonenumber")
+  private PhoneNumber phonenumber;
+
+  /**
+   * Phone number control value: {@code value.phonenumber = { area, number }}.
+   * e.g. area="+62", number="87827717730"
+   */
+  @Data
+  public static class PhoneNumber implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private String area;
+    private String number;
+  }
+
   /**
    * The type Date.
    */


### PR DESCRIPTION
## Problem

The WeCom approval API returns PhoneNumber control values as:

```json
"value": { "phonenumber": { "area": "+62", "number": "87827717730" } }
```

`ContentValue` has no `phonenumber` field, so Gson silently drops it during
`getApprovalDetail` deserialization. Any code calling `valueObj.getPhonenumber()`
always gets `null`, even when the user filled in a valid phone number.

## Fix

Add a `PhoneNumber` nested class and a corresponding `phonenumber` field
with `@SerializedName("phonenumber")` to `ContentValue`.

## Test

Deserialize the following JSON fragment into `ContentValue` and assert
`getPhonenumber().getNumber()` equals `"87827717730"`:

```json
{ "phonenumber": { "area": "+62", "number": "87827717730" } }
```