### PR TITLE
微信支付:默认使用公钥模式，全部v3接口添加Wechatpay-Serial请求头

### DIFF
--- a/solon-plugins/wx-java-pay-solon-plugin/src/main/java/com/binarywang/solon/wxjava/pay/config/WxPayAutoConfiguration.java
+++ b/solon-plugins/wx-java-pay-solon-plugin/src/main/java/com/binarywang/solon/wxjava/pay/config/WxPayAutoConfiguration.java
@@ -55,7 +55,7 @@ public class WxPayAutoConfiguration {
     payConfig.setPrivateKeyPath(StringUtils.trimToNull(this.properties.getPrivateKeyPath()));
     payConfig.setPrivateCertPath(StringUtils.trimToNull(this.properties.getPrivateCertPath()));
     payConfig.setCertSerialNo(StringUtils.trimToNull(this.properties.getCertSerialNo()));
-    payConfig.setApiV3Key(StringUtils.trimToNull(this.properties.getApiv3Key()));
+    payConfig.setApiV3Key(StringUtils.trimToNull(this.properties.getApiV3Key()));
     payConfig.setPublicKeyId(StringUtils.trimToNull(this.properties.getPublicKeyId()));
     payConfig.setPublicKeyPath(StringUtils.trimToNull(this.properties.getPublicKeyPath()));
     payConfig.setApiHostUrl(StringUtils.trimToNull(this.properties.getApiHostUrl()));

--- a/solon-plugins/wx-java-pay-solon-plugin/src/main/java/com/binarywang/solon/wxjava/pay/properties/WxPayProperties.java
+++ b/solon-plugins/wx-java-pay-solon-plugin/src/main/java/com/binarywang/solon/wxjava/pay/properties/WxPayProperties.java
@@ -59,7 +59,7 @@ public class WxPayProperties {
   /**
    * apiV3秘钥
    */
-  private String apiv3Key;
+  private String apiV3Key;
 
   /**
    * 微信支付分回调地址
@@ -114,13 +114,13 @@ public class WxPayProperties {
   private String apiHostUrl;
 
   /**
-   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认不添加
+   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认添加
    */
-  private boolean strictlyNeedWechatPaySerial = false;
+  private boolean strictlyNeedWechatPaySerial = true;
 
   /**
-   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认不使用
+   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认使用
    */
-  private boolean fullPublicKeyModel = false;
+  private boolean fullPublicKeyModel = true;
 
 }

--- a/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/README.md
+++ b/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/README.md
@@ -255,8 +255,8 @@ public class PayService {
 | payScorePermissionNotifyUrl | 支付分授权回调地址 | 无 |
 | useSandboxEnv | 是否使用沙箱环境 | false |
 | apiHostUrl | 自定义API主机地址 | https://api.mch.weixin.qq.com |
-| strictlyNeedWechatPaySerial | 是否所有V3请求都添加序列号头 | false |
-| fullPublicKeyModel | 是否完全使用公钥模式 | false |
+| strictlyNeedWechatPaySerial | 是否所有V3请求都添加序列号头 | true |
+| fullPublicKeyModel | 是否完全使用公钥模式 | true |
 | publicKeyId | 公钥ID | 无 |
 | publicKeyPath | 公钥文件路径 | 无 |
 

--- a/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/README.md
+++ b/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/README.md
@@ -104,7 +104,7 @@ wx:
 # 公众号1配置
 wx.pay.configs.wx1234567890abcdef.app-id=wx1234567890abcdef
 wx.pay.configs.wx1234567890abcdef.mch-id=1234567890
-wx.pay.configs.wx1234567890abcdef.apiv3-key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+wx.pay.configs.wx1234567890abcdef.api-v3-key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 wx.pay.configs.wx1234567890abcdef.cert-serial-no=62C6CEAA360BCxxxxxxxxxxxxxxx
 wx.pay.configs.wx1234567890abcdef.private-key-path=classpath:cert/app1/apiclient_key.pem
 wx.pay.configs.wx1234567890abcdef.private-cert-path=classpath:cert/app1/apiclient_cert.pem
@@ -113,7 +113,7 @@ wx.pay.configs.wx1234567890abcdef.notify-url=https://example.com/pay/notify
 # 公众号2配置
 wx.pay.configs.wx9876543210fedcba.app-id=wx9876543210fedcba
 wx.pay.configs.wx9876543210fedcba.mch-id=9876543210
-wx.pay.configs.wx9876543210fedcba.apiv3-key=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+wx.pay.configs.wx9876543210fedcba.api-v3-key=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 wx.pay.configs.wx9876543210fedcba.cert-serial-no=73D7DFBB471CDxxxxxxxxxxxxxxx
 wx.pay.configs.wx9876543210fedcba.private-key-path=classpath:cert/app2/apiclient_key.pem
 wx.pay.configs.wx9876543210fedcba.private-cert-path=classpath:cert/app2/apiclient_cert.pem
@@ -312,5 +312,5 @@ wx:
 ## 更多信息
 
 - [WxJava 项目首页](https://github.com/Wechat-Group/WxJava)
-- [微信支付官方文档](https://pay.weixin.qq.com/wiki/doc/api/)
-- [微信支付V3接口文档](https://pay.weixin.qq.com/wiki/doc/apiv3/index.shtml)
+- [微信支付V2文档](https://pay.weixin.qq.com/doc/v2)
+- [微信支付V3接口文档](https://pay.weixin.qq.com/doc/v3/merchant/4012062524)

--- a/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/properties/WxPaySingleProperties.java
+++ b/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/properties/WxPaySingleProperties.java
@@ -58,7 +58,7 @@ public class WxPaySingleProperties implements Serializable {
   /**
    * apiV3秘钥.
    */
-  private String apiv3Key;
+  private String apiV3Key;
 
   /**
    * 微信支付异步回调地址，通知url必须为直接可访问的url，不能携带参数.
@@ -113,12 +113,12 @@ public class WxPaySingleProperties implements Serializable {
   private String apiHostUrl;
 
   /**
-   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认不添加.
+   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认添加.
    */
-  private boolean strictlyNeedWechatPaySerial = false;
+  private boolean strictlyNeedWechatPaySerial = true;
 
   /**
-   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认不使用.
+   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认使用.
    */
-  private boolean fullPublicKeyModel = false;
+  private boolean fullPublicKeyModel = true;
 }

--- a/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/service/WxPayMultiServicesImpl.java
+++ b/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/service/WxPayMultiServicesImpl.java
@@ -79,7 +79,7 @@ public class WxPayMultiServicesImpl implements WxPayMultiServices {
     payConfig.setPrivateKeyPath(StringUtils.trimToNull(properties.getPrivateKeyPath()));
     payConfig.setPrivateCertPath(StringUtils.trimToNull(properties.getPrivateCertPath()));
     payConfig.setCertSerialNo(StringUtils.trimToNull(properties.getCertSerialNo()));
-    payConfig.setApiV3Key(StringUtils.trimToNull(properties.getApiv3Key()));
+    payConfig.setApiV3Key(StringUtils.trimToNull(properties.getApiV3Key()));
     payConfig.setPublicKeyId(StringUtils.trimToNull(properties.getPublicKeyId()));
     payConfig.setPublicKeyPath(StringUtils.trimToNull(properties.getPublicKeyPath()));
     payConfig.setApiHostUrl(StringUtils.trimToNull(properties.getApiHostUrl()));

--- a/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/src/test/java/com/binarywang/spring/starter/wxjava/pay/WxPayMultiServicesTest.java
+++ b/spring-boot-starters/wx-java-pay-multi-spring-boot-starter/src/test/java/com/binarywang/spring/starter/wxjava/pay/WxPayMultiServicesTest.java
@@ -57,7 +57,7 @@ public class WxPayMultiServicesTest {
     assertNotNull(app2Config, "app2 configuration should exist");
     assertEquals("wx2222222222222222", app2Config.getAppId());
     assertEquals("2222222222", app2Config.getMchId());
-    assertEquals("22222222222222222222222222222222", app2Config.getApiv3Key());
+    assertEquals("22222222222222222222222222222222", app2Config.getApiV3Key());
   }
 
   @Test

--- a/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/config/WxPayAutoConfiguration.java
+++ b/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/config/WxPayAutoConfiguration.java
@@ -59,7 +59,7 @@ public class WxPayAutoConfiguration {
     payConfig.setPrivateKeyPath(StringUtils.trimToNull(this.properties.getPrivateKeyPath()));
     payConfig.setPrivateCertPath(StringUtils.trimToNull(this.properties.getPrivateCertPath()));
     payConfig.setCertSerialNo(StringUtils.trimToNull(this.properties.getCertSerialNo()));
-    payConfig.setApiV3Key(StringUtils.trimToNull(this.properties.getApiv3Key()));
+    payConfig.setApiV3Key(StringUtils.trimToNull(this.properties.getApiV3Key()));
     payConfig.setPublicKeyId(StringUtils.trimToNull(this.properties.getPublicKeyId()));
     payConfig.setPublicKeyPath(StringUtils.trimToNull(this.properties.getPublicKeyPath()));
     payConfig.setApiHostUrl(StringUtils.trimToNull(this.properties.getApiHostUrl()));

--- a/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/properties/WxPayProperties.java
+++ b/spring-boot-starters/wx-java-pay-spring-boot-starter/src/main/java/com/binarywang/spring/starter/wxjava/pay/properties/WxPayProperties.java
@@ -57,7 +57,7 @@ public class WxPayProperties {
   /**
    * apiV3秘钥
    */
-  private String apiv3Key;
+  private String apiV3Key;
 
   /**
    * 微信支付异步回调地址，通知url必须为直接可访问的url，不能携带参数
@@ -112,13 +112,13 @@ public class WxPayProperties {
   private String apiHostUrl;
 
   /**
-   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认不添加
+   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认添加
    */
-  private boolean strictlyNeedWechatPaySerial = false;
+  private boolean strictlyNeedWechatPaySerial = true;
 
   /**
-   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认不使用
+   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认使用
    */
-  private boolean fullPublicKeyModel = false;
+  private boolean fullPublicKeyModel = true;
 
 }

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -272,12 +272,12 @@ public class WxPayConfig {
   /**
    * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认添加
    */
-  private boolean strictlyNeedWechatPaySerial = false;
+  private boolean strictlyNeedWechatPaySerial = true;
 
   /**
    * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认使用
    */
-  private boolean fullPublicKeyModel = false;
+  private boolean fullPublicKeyModel = true;
 
   /**
    * 返回所设置的微信支付接口请求地址域名.

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/config/WxPayConfig.java
@@ -270,12 +270,12 @@ public class WxPayConfig {
   private Verifier verifier;
 
   /**
-   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认不添加
+   * 是否将全部v3接口的请求都添加Wechatpay-Serial请求头，默认添加
    */
   private boolean strictlyNeedWechatPaySerial = false;
 
   /**
-   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认不使用
+   * 是否完全使用公钥模式(用以微信从平台证书到公钥的灰度切换)，默认使用
    */
   private boolean fullPublicKeyModel = false;
 


### PR DESCRIPTION
1. 默认使用公钥模式
2. 全部v3接口添加Wechatpay-Serial请求头
3. 调整apiV3秘钥命名
4. 更新了readme中v2、v3新版文档地址