### PR TITLE
Support refund funds account in V3 requests

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayRefundV3Request.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxPayRefundV3Request.java
@@ -86,6 +86,24 @@ public class WxPayRefundV3Request implements Serializable {
   private String notifyUrl;
   /**
    * <pre>
+   * 字段名：退款资金来源
+   * 变量名：funds_account
+   * 是否必填：否
+   * 类型：string[1, 32]
+   * 描述：
+   *  若传递此参数则使用对应的资金账户退款，否则默认使用未结算资金退款（仅对老资金流商户适用）
+   *  示例值：
+   *    UNSETTLED : 未结算资金
+   *    AVAILABLE : 可用余额
+   *    UNAVAILABLE : 不可用余额
+   *    OPERATION : 运营户
+   *    BASIC : 基本账户（含可用余额和不可用余额）
+   * </pre>
+   */
+  @SerializedName(value = "funds_account")
+  private String fundsAccount;
+  /**
+   * <pre>
    * 字段名：订单金额
    * 变量名：amount
    * 是否必填：是
@@ -152,6 +170,53 @@ public class WxPayRefundV3Request implements Serializable {
      */
     @SerializedName(value = "currency")
     private String currency;
+    /**
+     * <pre>
+     * 字段名：退款出资账户及金额
+     * 变量名：from
+     * 是否必填：否
+     * 类型：array
+     * 描述：
+     *  退款出资的账户类型及金额信息
+     * </pre>
+     */
+    @SerializedName(value = "from")
+    private List<From> from;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class From implements Serializable {
+    private static final long serialVersionUID = 1L;
+    /**
+     * <pre>
+     * 字段名：出资账户类型
+     * 变量名：account
+     * 是否必填：是
+     * 类型：string[1, 32]
+     * 描述：
+     *  下面枚举值多选一。
+     *  枚举值：
+     *  AVAILABLE : 可用余额
+     *  UNAVAILABLE : 不可用余额
+     *  示例值：AVAILABLE
+     * </pre>
+     */
+    @SerializedName(value = "account")
+    private String account;
+    /**
+     * <pre>
+     * 字段名：出资金额
+     * 变量名：amount
+     * 是否必填：是
+     * 类型：int
+     * 描述：
+     *  对应账户出资金额
+     *  示例值：444
+     * </pre>
+     */
+    @SerializedName(value = "amount")
+    private Integer amount;
   }
 
   @Data

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxPayRefundV3RequestTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxPayRefundV3RequestTest.java
@@ -1,0 +1,56 @@
+package com.github.binarywang.wxpay.bean.request;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link WxPayRefundV3Request} 单元测试
+ *
+ */
+public class WxPayRefundV3RequestTest {
+
+  @Test
+  public void testFundsAccountSerialization() {
+    WxPayRefundV3Request request = new WxPayRefundV3Request();
+    request.setOutRefundNo("1217752501201407033233368018");
+    request.setFundsAccount("AVAILABLE");
+
+    Gson gson = new Gson();
+    String json = gson.toJson(request);
+    JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+
+    assertThat(jsonObject.has("funds_account")).isTrue();
+    assertThat(jsonObject.get("funds_account").getAsString()).isEqualTo("AVAILABLE");
+  }
+
+  @Test
+  public void testAmountFromSerialization() {
+    WxPayRefundV3Request.From from = new WxPayRefundV3Request.From();
+    from.setAccount("AVAILABLE");
+    from.setAmount(444);
+
+    WxPayRefundV3Request.Amount amount = new WxPayRefundV3Request.Amount();
+    amount.setRefund(888);
+    amount.setTotal(888);
+    amount.setCurrency("CNY");
+    amount.setFrom(Collections.singletonList(from));
+
+    WxPayRefundV3Request request = new WxPayRefundV3Request();
+    request.setAmount(amount);
+
+    Gson gson = new Gson();
+    String json = gson.toJson(request);
+    JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+    JsonArray fromJson = jsonObject.getAsJsonObject("amount").getAsJsonArray("from");
+
+    assertThat(fromJson).hasSize(1);
+    assertThat(fromJson.get(0).getAsJsonObject().get("account").getAsString()).isEqualTo("AVAILABLE");
+    assertThat(fromJson.get(0).getAsJsonObject().get("amount").getAsInt()).isEqualTo(444);
+  }
+}


### PR DESCRIPTION
为普通商户版 `WxPayRefundV3Request` 补齐退款资金来源参数，和现有服务商版字段保持一致。变更包含 `funds_account` 以及 `amount.from` 出资账户明细，便于在退款申请时指定可用余额或未结算资金等来源。

测试：尝试运行 `./others/mvnw -pl weixin-java-pay -Dtest=WxPayRefundV3RequestTest test -DskipITs`，但仓库缺少 `org.apache.maven.wrapper.MavenWrapperMain` 相关 wrapper jar，当前环境未能执行。