### PR TITLE
#4052 完善 NFC 小程序 scheme 接口测试

### DIFF
--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaSchemeService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaSchemeService.java
@@ -24,7 +24,7 @@ public interface WxMaSchemeService {
   String generate(WxMaGenerateSchemeRequest request) throws WxErrorException;
   /**
    * 获取NFC 的小程序 scheme
-   *文档地址：https://developers.weixin.qq.com/miniprogram/dev/OpenApiDoc/qrcode-link/url-scheme/generateNFCScheme.html
+   *文档地址：https://developers.weixin.qq.com/miniprogram/dev/server/API/qrcode-link/url-scheme/api_generatenfcscheme.html
    * @param request 请求参数
    * @throws WxErrorException 生成失败时抛出，具体错误码请看文档
    */

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaSchemeServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaSchemeServiceImpl.java
@@ -42,7 +42,7 @@ public class WxMaSchemeServiceImpl implements WxMaSchemeService {
 
   /**
    * 获取NFC 的小程序 scheme
-   * 文档地址：https://developers.weixin.qq.com/miniprogram/dev/OpenApiDoc/qrcode-link/url-scheme/generateNFCScheme.html
+   * 文档地址：https://developers.weixin.qq.com/miniprogram/dev/server/API/qrcode-link/url-scheme/api_generatenfcscheme.html
    *
    * @param request 请求参数
    * @throws WxErrorException 生成失败时抛出，具体错误码请看文档

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaEmployeeRelationServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaEmployeeRelationServiceImplTest.java
@@ -66,7 +66,7 @@ public class WxMaEmployeeRelationServiceImplTest {
   @Test
   public void testUnbinduserb2cauthinfo() throws WxErrorException {
     WxMaUnbindEmployeeRequest wxMaUnbindEmployeeRequest = new WxMaUnbindEmployeeRequest();
-    wxMaUnbindEmployeeRequest.setOpenidList(List.of("o0uBr12b1zdgCk1qDoBivmSYb9GA"));
+    wxMaUnbindEmployeeRequest.setOpenidList(Collections.singletonList("o0uBr12b1zdgCk1qDoBivmSYb9GA"));
     this.wxService.getEmployeeRelationService().unbindEmployee(wxMaUnbindEmployeeRequest);
   }
 

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/bean/scheme/WxMaGenerateNfcSchemeRequestTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/bean/scheme/WxMaGenerateNfcSchemeRequestTest.java
@@ -1,0 +1,33 @@
+package cn.binarywang.wx.miniapp.bean.scheme;
+
+import me.chanjar.weixin.common.util.json.GsonParser;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WxMaGenerateNfcSchemeRequestTest {
+  @Test
+  public void testToJson() {
+    WxMaGenerateNfcSchemeRequest request = WxMaGenerateNfcSchemeRequest.newBuilder()
+      .jumpWxa(WxMaGenerateNfcSchemeRequest.JumpWxa.newBuilder()
+        .path("pages/index/index")
+        .query("device=demo")
+        .envVersion("trial")
+        .build())
+      .modelId("model-demo")
+      .sn("sn-demo")
+      .build();
+
+    String expectedJson = "{\n"
+      + "  \"jump_wxa\": {\n"
+      + "    \"path\": \"pages/index/index\",\n"
+      + "    \"query\": \"device=demo\",\n"
+      + "    \"env_version\": \"trial\"\n"
+      + "  },\n"
+      + "  \"model_id\": \"model-demo\",\n"
+      + "  \"sn\": \"sn-demo\"\n"
+      + "}";
+
+    assertThat(request.toJson()).isEqualTo(GsonParser.parse(expectedJson).toString());
+  }
+}


### PR DESCRIPTION
## 变更内容
- 补充 `WxMaGenerateNfcSchemeRequest` 的 JSON 序列化测试，覆盖 `jump_wxa`、`model_id`、`sn` 等官方字段
- 将 NFC scheme 接口 JavaDoc 链接更新为 issue 中提供的官方文档地址
- 修复 miniapp 测试中的 `List.of` 用法，避免 Java 8 testCompile 失败

## 验证
- `mvn -pl weixin-java-miniapp -Dtest=WxMaGenerateNfcSchemeRequestTest test`：首次因既有 `List.of` Java 8 兼容性问题失败，已修复
- `mvn -pl weixin-java-miniapp -Dtest=WxMaGenerateNfcSchemeRequestTest test`：编译通过，但项目 surefire 默认配置跳过测试执行
- `java -cp "weixin-java-miniapp/target/test-classes:weixin-java-miniapp/target/classes:$(cat weixin-java-miniapp/target/test-classpath.txt)" org.testng.TestNG -testclass cn.binarywang.wx.miniapp.bean.scheme.WxMaGenerateNfcSchemeRequestTest`：1 个测试通过

Closes #4052