### PR TITLE
Return null from GsonHelper array getters for a non-array property

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/GsonHelper.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/json/GsonHelper.java
@@ -108,7 +108,7 @@ public class GsonHelper {
   }
 
   public static Integer[] getIntArray(JsonObject o, String string) {
-    JsonArray jsonArray = getAsJsonArray(o.getAsJsonArray(string));
+    JsonArray jsonArray = getAsJsonArray(o.get(string));
     if (jsonArray == null) {
       return null;
     }
@@ -122,7 +122,7 @@ public class GsonHelper {
   }
 
   public static String[] getStringArray(JsonObject o, String string) {
-    JsonArray jsonArray = getAsJsonArray(o.getAsJsonArray(string));
+    JsonArray jsonArray = getAsJsonArray(o.get(string));
     if (jsonArray == null) {
       return null;
     }
@@ -136,7 +136,7 @@ public class GsonHelper {
   }
 
   public static Long[] getLongArray(JsonObject o, String string) {
-    JsonArray jsonArray = getAsJsonArray(o.getAsJsonArray(string));
+    JsonArray jsonArray = getAsJsonArray(o.get(string));
     if (jsonArray == null) {
       return null;
     }
@@ -150,7 +150,7 @@ public class GsonHelper {
   }
 
   public static JsonArray getAsJsonArray(JsonElement element) {
-    return element == null ? null : element.getAsJsonArray();
+    return (element == null || !element.isJsonArray()) ? null : element.getAsJsonArray();
   }
 
   /**

--- a/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/json/GsonHelperTest.java
+++ b/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/json/GsonHelperTest.java
@@ -136,4 +136,29 @@ public class GsonHelperTest {
     System.out.println(GsonHelper.buildJsonObject(1, true, "jsonElement", new JsonObject()));
     System.out.println(GsonHelper.buildJsonObject("num", 2, "string", "cde", "char", 'a', "bool", true));
   }
+
+  /**
+   * If the JSON property exists but is NOT a JSON array (e.g. a plain string),
+   * getIntArray should return null gracefully rather than throwing ClassCastException.
+   */
+  @Test
+  public void testGetIntArrayNonArrayProperty() {
+    JsonObject json = new JsonObject();
+    json.addProperty("items", "not-an-array");
+    assertThat(GsonHelper.getIntArray(json, "items")).isNull();
+  }
+
+  @Test
+  public void testGetStringArrayNonArrayProperty() {
+    JsonObject json = new JsonObject();
+    json.addProperty("items", 123);
+    assertThat(GsonHelper.getStringArray(json, "items")).isNull();
+  }
+
+  @Test
+  public void testGetLongArrayNonArrayProperty() {
+    JsonObject json = new JsonObject();
+    json.addProperty("items", "not-an-array");
+    assertThat(GsonHelper.getLongArray(json, "items")).isNull();
+  }
 }


### PR DESCRIPTION
`GsonHelper.getIntArray`, `getStringArray` and `getLongArray` call gson's `JsonObject.getAsJsonArray(memberName)`, which casts the member to `JsonArray`. If the property exists but is **not** a JSON array (e.g. a string or number), this throws an unchecked `ClassCastException` instead of returning gracefully.

This passes the raw element via `o.get(string)` to the existing null-safe `getAsJsonArray(JsonElement)` helper, and makes that helper treat a non-array element the same as null — so the three methods return `null` for a non-array property, matching how they already handle a missing/null property. The other caller of the helper (`WxOpenAuthorizationInfoGsonAdapter`) is unaffected for valid arrays and becomes null-safe for malformed input.

Adds regression tests for the three methods that fail before the change (CCE) and pass after.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
