### PR TITLE
Read the full stream in FileUtils.imageToBase64ByStream

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/fs/FileUtils.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/fs/FileUtils.java
@@ -57,13 +57,10 @@ public class FileUtils {
    * @return base64编码
    */
   public static String imageToBase64ByStream(InputStream in) {
-    byte[] data = null;
     // 读取图片字节数组
     try {
-      data = new byte[in.available()];
-      in.read(data);
       // 返回Base64编码过的字节数组字符串
-      return Base64.getEncoder().encodeToString(data);
+      return Base64.getEncoder().encodeToString(IOUtils.toByteArray(in));
     } catch (IOException e) {
       e.printStackTrace();
     } finally {

--- a/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/fs/FileUtilsTest.java
+++ b/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/fs/FileUtilsTest.java
@@ -6,8 +6,10 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.Base64;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,5 +32,31 @@ public class FileUtilsTest {
 
   @Test
   public void testImageToBase64ByStream() {
+    byte[] original = new byte[5000];
+    for (int i = 0; i < original.length; i++) {
+      original[i] = (byte) (i % 256);
+    }
+    // A stream that returns at most 16 bytes per read() call (like a network stream),
+    // so a single in.read(buffer) does not fill the buffer.
+    InputStream chunked = new InputStream() {
+      private final ByteArrayInputStream delegate = new ByteArrayInputStream(original);
+
+      @Override
+      public int read() {
+        return delegate.read();
+      }
+
+      @Override
+      public int read(byte[] b, int off, int len) {
+        return delegate.read(b, off, Math.min(len, 16));
+      }
+
+      @Override
+      public int available() {
+        return delegate.available();
+      }
+    };
+    String result = FileUtils.imageToBase64ByStream(chunked);
+    assertThat(result).isEqualTo(Base64.getEncoder().encodeToString(original));
   }
 }


### PR DESCRIPTION
`imageToBase64ByStream` sizes its buffer from `in.available()` — only an estimate of the bytes immediately available, not the total — and then calls `in.read(data)` once, ignoring the returned count. Any stream that does not return all its bytes in a single `read` (buffered or network-backed streams are the common case) leaves the buffer partially filled with trailing zero bytes, producing a truncated/corrupted base64 string.

This reads the stream fully via `IOUtils.toByteArray(in)` (commons-io, already imported and used elsewhere in this file). Fills the previously-empty `testImageToBase64ByStream` with a regression test using a stream that returns at most 16 bytes per `read` — it fails before the change (truncated output) and passes after.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
