### PR TITLE
恢复默认 HTTP 客户端兼容性

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <version>4.12.0</version>
         <scope>provided</scope>
       </dependency>
-      <!-- HttpClient 5.x - 默认依赖（推荐使用） -->
+      <!-- HttpClient 5.x - 可选依赖，显式使用 HttpComponents 实现时需要 -->
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>

--- a/weixin-java-channel/pom.xml
+++ b/weixin-java-channel/pom.xml
@@ -32,12 +32,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxChannelServiceImpl.java
+++ b/weixin-java-channel/src/main/java/me/chanjar/weixin/channel/api/impl/WxChannelServiceImpl.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
  * @author <a href="https://github.com/lixize">Zeyes</a>
  */
 @Slf4j
-public class WxChannelServiceImpl extends WxChannelServiceHttpComponentsImpl {
+public class WxChannelServiceImpl extends WxChannelServiceHttpClientImpl {
 
   public WxChannelServiceImpl() {
   }

--- a/weixin-java-common/pom.xml
+++ b/weixin-java-common/pom.xml
@@ -24,17 +24,17 @@
       <artifactId>okhttp</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- HttpClient 5.x - 默认依赖（推荐使用） -->
+    <!-- HttpClient 5.x - 可选依赖，显式使用 HttpComponents 实现时需要 -->
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- HttpClient 4.x - 默认依赖（为了保持向后兼容） -->
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <artifactId>commons-logging</artifactId>
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/weixin-java-cp/pom.xml
+++ b/weixin-java-cp/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/weixin-java-miniapp/pom.xml
+++ b/weixin-java-miniapp/pom.xml
@@ -34,12 +34,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImpl.java
@@ -6,6 +6,6 @@ import lombok.extern.slf4j.Slf4j;
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
 @Slf4j
-public class WxMaServiceImpl extends WxMaServiceHttpComponentsImpl {
+public class WxMaServiceImpl extends WxMaServiceHttpClientImpl {
 
 }

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaServiceImplTest.java
@@ -11,6 +11,7 @@ import me.chanjar.weixin.common.bean.WxAccessTokenEntity;
 import me.chanjar.weixin.common.error.WxError;
 import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.error.WxMpErrorMsgEnum;
+import me.chanjar.weixin.common.util.http.HttpClientType;
 import me.chanjar.weixin.common.util.http.RequestExecutor;
 import org.apache.commons.lang3.StringUtils;
 import org.mockito.Mockito;
@@ -118,6 +119,8 @@ public class WxMaServiceImplTest {
 
   @Test
   public void testGetRequestType() {
+    assertThat(new WxMaServiceImpl().getRequestType()).isEqualTo(HttpClientType.APACHE_HTTP);
+    assertThat(new WxMaServiceHttpComponentsImpl().getRequestType()).isEqualTo(HttpClientType.HTTP_COMPONENTS);
   }
 
   @Test

--- a/weixin-java-mp/pom.xml
+++ b/weixin-java-mp/pom.xml
@@ -34,12 +34,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpServiceImpl.java
+++ b/weixin-java-mp/src/main/java/me/chanjar/weixin/mp/api/impl/WxMpServiceImpl.java
@@ -2,11 +2,11 @@ package me.chanjar.weixin.mp.api.impl;
 
 /**
  * <pre>
- * 默认接口实现类，使用apache httpClient 5实现
+ * 默认接口实现类，使用 Apache HttpClient 4 实现.
  * Created by Binary Wang on 2017-5-27.
  * </pre>
  *
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
-public class WxMpServiceImpl extends WxMpServiceHttpComponentsImpl {
+public class WxMpServiceImpl extends WxMpServiceHttpClientImpl {
 }

--- a/weixin-java-open/pom.xml
+++ b/weixin-java-open/pom.xml
@@ -51,12 +51,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenServiceImpl.java
+++ b/weixin-java-open/src/main/java/me/chanjar/weixin/open/api/impl/WxOpenServiceImpl.java
@@ -3,6 +3,6 @@ package me.chanjar.weixin.open.api.impl;
 /**
  * @author <a href="https://github.com/007gzs">007</a>
  */
-public class WxOpenServiceImpl extends WxOpenServiceHttpComponentsImpl {
+public class WxOpenServiceImpl extends WxOpenServiceApacheHttpClientImpl {
 
 }

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceImpl.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/impl/WxPayServiceImpl.java
@@ -2,11 +2,11 @@ package com.github.binarywang.wxpay.service.impl;
 
 /**
  * <pre>
- * 微信支付接口请求实现类，默认使用Apache HttpClient 5实现
+ * 微信支付接口请求实现类，默认使用 Apache HttpClient 4 实现.
  * Created by Binary Wang on 2017-7-8.
  * </pre>
  *
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
-public class WxPayServiceImpl extends WxPayServiceHttpComponentsImpl {
+public class WxPayServiceImpl extends WxPayServiceApacheHttpImpl {
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImplTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/impl/BaseWxPayServiceImplTest.java
@@ -59,6 +59,11 @@ public class BaseWxPayServiceImplTest {
   @Inject
   private WxPayService payService;
 
+  @Test
+  public void testDefaultImplUsesApacheHttpClient() {
+    assertThat(new WxPayServiceImpl()).isInstanceOf(WxPayServiceApacheHttpImpl.class);
+  }
+
   /**
    * Test method for {@link WxPayService#unifiedOrder(WxPayUnifiedOrderRequest)}.
    *

--- a/weixin-java-qidian/pom.xml
+++ b/weixin-java-qidian/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>

--- a/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/api/impl/WxQidianServiceImpl.java
+++ b/weixin-java-qidian/src/main/java/me/chanjar/weixin/qidian/api/impl/WxQidianServiceImpl.java
@@ -2,11 +2,11 @@ package me.chanjar.weixin.qidian.api.impl;
 
 /**
  * <pre>
- * 默认接口实现类，使用apache httpClient 5实现
+ * 默认接口实现类，使用 Apache HttpClient 4 实现.
  * Created by Binary Wang on 2017-5-27.
  * </pre>
  *
  * @author <a href="https://github.com/binarywang">Binary Wang</a>
  */
-public class WxQidianServiceImpl extends WxQidianServiceHttpComponentsImpl {
+public class WxQidianServiceImpl extends WxQidianServiceHttpClientImpl {
 }


### PR DESCRIPTION
## 变更说明

修复 [Gitee issue IJYMVW](https://gitee.com/binary/weixin-java-tools/issues/IJYMVW)提到的 4.8.4+ 默认引入/默认使用 HttpClient5 导致非 Starter 手动集成场景依赖树变重、排除 HC5 后可能缺类的问题。

本次调整：

- 将非 Starter 的默认 `*ServiceImpl` 恢复为 Apache HttpClient 4 实现，显式的 `*HttpComponentsImpl` 仍保留给需要 HttpClient5 的用户和 Starter 配置使用。
- 将 `weixin-java-common` 以及相关业务模块中的 HC4 依赖恢复为 compile 传递依赖，`httpclient5` 调整为 provided。
- 补充 miniapp/pay 默认实现类型断言，防止默认类再次回退到 HC5。

## 影响

手动 `new WxMaServiceImpl()`、`new WxPayServiceImpl()` 以及 mp/channel/qidian/open/cp 默认实现时，默认依赖树回到 HC4 兼容路径。需要 HC5 的用户仍可显式使用 `*HttpComponentsImpl` 或通过 Starter 的 `HttpComponents` 配置选择。

## 验证

- `mvn -pl weixin-java-common,weixin-java-miniapp,weixin-java-pay,weixin-java-mp,weixin-java-channel,weixin-java-qidian,weixin-java-open,weixin-java-cp -am -DskipTests compile`
- `mvn -pl weixin-java-miniapp,weixin-java-mp,weixin-java-channel,weixin-java-qidian,weixin-java-open,weixin-java-cp dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5,org.apache.httpcomponents:httpclient,org.apache.httpcomponents:httpmime -Dscope=compile`
- 使用 JShell 验证 `WxMaServiceImpl` 默认 `APACHE_HTTP`、`WxMaServiceHttpComponentsImpl` 仍为 `HTTP_COMPONENTS`、`WxPayServiceImpl` 默认继承 `WxPayServiceApacheHttpImpl`。

说明：项目根 POM 中 surefire 配置了 `<skip>true</skip>`，Maven 定向测试命令会显示 `Tests are skipped`，因此额外用 JShell 执行了新增断言对应的运行时验证。
