### PR TITLE
fix: 小程序纯签约移除version参数

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequest.java
@@ -102,21 +102,6 @@ public class WxMaEntrustRequest extends BaseWxPayRequest {
 
   /**
    * <pre>
-   * 版本号
-   * sign
-   * 是
-   * string(8)
-   * 1.0
-   * 固定值1.0
-   * </pre>
-   */
-  @Required
-  @XStreamAlias("version")
-  private String version;
-
-
-  /**
-   * <pre>
    * 时间戳
    * timestamp
    * 是


### PR DESCRIPTION
1. 纯小程序签约无version参数，使用该参数生成的签名在跳转签约的时候会提示“商家系统错误”

<img width="1080" height="2376" alt="Screenshot_2026-07-20-16-12-50-90_e39d2c7de19156b0683cd93e8735f348" src="https://github.com/user-attachments/assets/467b9ef2-b781-4d00-9d29-bf7158a4e335" />
