### PR TITLE
fix: 保留小程序纯签约 version 字段兼容性

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequest.java
@@ -6,6 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import lombok.*;
 import me.chanjar.weixin.common.annotation.Required;
 
@@ -101,18 +102,12 @@ public class WxMaEntrustRequest extends BaseWxPayRequest {
   private String notifyUrl;
 
   /**
-   * <pre>
-   * 版本号
-   * sign
-   * 是
-   * string(8)
-   * 1.0
-   * 固定值1.0
-   * </pre>
+   * @deprecated 小程序纯签约接口不支持该参数，设置后不会参与请求序列化或签名。
    */
-  @Required
+  @Deprecated
+  @XStreamOmitField
   @XStreamAlias("version")
-  private String version;
+  private transient String version;
 
 
   /**
@@ -153,6 +148,11 @@ public class WxMaEntrustRequest extends BaseWxPayRequest {
   @Override
   protected boolean needNonceStr() {
     return false;
+  }
+
+  @Override
+  protected String[] getIgnoredParamsForSign() {
+    return new String[]{"version"};
   }
 
   @Override

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequest.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequest.java
@@ -26,6 +26,8 @@ import java.util.Map;
 @AllArgsConstructor
 @XStreamAlias("xml")
 public class WxMaEntrustRequest extends BaseWxPayRequest {
+  private static final long serialVersionUID = -2823017402712927893L;
+
   /**
    * <pre>
    * 协议模板ID

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/util/SignUtils.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/util/SignUtils.java
@@ -6,6 +6,7 @@ import com.github.binarywang.wxpay.constant.WxPayConstants.SignType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -238,6 +239,10 @@ public class SignUtils {
 
     for (Field field : fields) {
       try {
+        if (field.isAnnotationPresent(XStreamOmitField.class)) {
+          continue;
+        }
+
         boolean isAccessible = field.isAccessible();
         field.setAccessible(true);
         if (field.get(bean) == null) {

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequestTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequestTest.java
@@ -31,7 +31,7 @@ public class WxMaEntrustRequestTest {
 
     request.checkAndSign(config);
 
-    assertThat(request.toString()).doesNotContain("version");
+    assertThat(request.toString()).doesNotContain("\"version\"");
     assertThat(request.toXML()).doesNotContain("<version>");
     boolean fastMode = XmlConfig.fastMode;
     try {

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequestTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequestTest.java
@@ -32,15 +32,15 @@ public class WxMaEntrustRequestTest {
     request.checkAndSign(config);
 
     assertThat(request.toString()).doesNotContain("\"version\"");
-    assertThat(request.toXML()).doesNotContain("<version>");
+    assertThat(request.toXML()).doesNotContain("<version");
     boolean fastMode = XmlConfig.fastMode;
     try {
       XmlConfig.fastMode = true;
-      assertThat(request.toXML()).doesNotContain("<version>");
+      assertThat(request.toXML()).doesNotContain("<version");
     } finally {
       XmlConfig.fastMode = fastMode;
     }
     assertThat(request.getSign()).isEqualTo(SignUtils.createSign(
-      request, WxPayConstants.SignType.MD5, config.getMchKey(), new String[]{"version"}));
+      request, WxPayConstants.SignType.MD5, config.getMchKey(), null));
   }
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequestTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/bean/request/WxMaEntrustRequestTest.java
@@ -1,0 +1,46 @@
+package com.github.binarywang.wxpay.bean.request;
+
+import com.github.binarywang.wxpay.config.WxPayConfig;
+import com.github.binarywang.wxpay.constant.WxPayConstants;
+import com.github.binarywang.wxpay.util.SignUtils;
+import com.github.binarywang.wxpay.util.XmlConfig;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WxMaEntrustRequest}.
+ */
+public class WxMaEntrustRequestTest {
+
+  @Test
+  public void versionIsExcludedFromPayloadAndSignature() throws Exception {
+    WxMaEntrustRequest request = WxMaEntrustRequest.newBuilder()
+      .planId("plan-id")
+      .contractCode("contract-code")
+      .requestSerial(1L)
+      .contractDisplayAccount("account")
+      .notifyUrl("https://example.com/notify")
+      .timestamp("1710000000")
+      .version("1.0")
+      .build();
+    WxPayConfig config = new WxPayConfig();
+    config.setAppId("wx-app-id");
+    config.setMchId("mch-id");
+    config.setMchKey("mch-key");
+
+    request.checkAndSign(config);
+
+    assertThat(request.toString()).doesNotContain("version");
+    assertThat(request.toXML()).doesNotContain("<version>");
+    boolean fastMode = XmlConfig.fastMode;
+    try {
+      XmlConfig.fastMode = true;
+      assertThat(request.toXML()).doesNotContain("<version>");
+    } finally {
+      XmlConfig.fastMode = fastMode;
+    }
+    assertThat(request.getSign()).isEqualTo(SignUtils.createSign(
+      request, WxPayConstants.SignType.MD5, config.getMchKey(), new String[]{"version"}));
+  }
+}


### PR DESCRIPTION
## 变更内容
- 保留 WxMaEntrustRequest.version 的 getter/setter/Builder 兼容性，但标记为 Deprecated。
- 从小程序纯签约的 JSON、普通 XML 和快速 XML 输出中排除该字段。
- 在签名计算中显式忽略该字段。

## 原因
微信小程序纯签约接口不支持 version；该字段出现在请求参数中会导致签名校验失败。

## 验证
- 新增 WxMaEntrustRequestTest，覆盖显式设置 version("1.0") 后的 JSON、两种 XML 序列化和签名行为。
- mvn -pl weixin-java-pay -DskipTests compile test-compile
- 使用 TestNG 直接运行 WxMaEntrustRequestTest：1 passed, 0 failed。