### PR TITLE
feat: 小程序获取手机号支持openid校验

### DIFF
--- a/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/DataUtils.java
+++ b/weixin-java-common/src/main/java/me/chanjar/weixin/common/util/DataUtils.java
@@ -17,8 +17,10 @@ public class DataUtils {
    */
   public static <E> E handleDataWithSecret(E data) {
     E dataForLog = data;
-    if (data instanceof String && StringUtils.contains((String) data, "secret=")) {
-      dataForLog = (E) RegExUtils.replaceAll((String) data, "(^|[?&])secret=[^&]*", "$1secret=******");
+    if (data instanceof String) {
+      String stringData = (String) data;
+      stringData = RegExUtils.replaceAll(stringData, "(^|[?&])secret=[^&]*", "$1secret=******");
+      dataForLog = (E) RegExUtils.replaceAll(stringData, "(\\\"openid\\\"\\s*:\\s*\\\")[^\\\"]*(\\\")", "$1******$2");
     }
     return dataForLog;
   }

--- a/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/DataUtilsTest.java
+++ b/weixin-java-common/src/test/java/me/chanjar/weixin/common/util/DataUtilsTest.java
@@ -47,4 +47,14 @@ public class DataUtilsTest {
     assertFalse(s.contains("%2F"), "Encoded characters in the secret must be masked too");
     assertTrue(s.contains("&secret=******&"), "Secret should be replaced with asterisks");
   }
+
+  @Test
+  public void testHandleDataWithOpenidInJson() {
+    String data = "{\"code\":\"phone-code\",\"openid\":\"user-openid\"}";
+
+    String result = DataUtils.handleDataWithSecret(data);
+
+    assertFalse(result.contains("user-openid"));
+    assertTrue(result.contains("\"openid\":\"******\""));
+  }
 }

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaUserService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaUserService.java
@@ -74,6 +74,17 @@ public interface WxMaUserService {
   WxMaPhoneNumberInfo getPhoneNumber(String code) throws WxErrorException;
 
   /**
+   * 获取手机号信息，并校验手机号获取凭证与用户的绑定关系。
+   *
+   * @param code 每个code只能使用一次，code的有效期为5min。code获取方式参考<a href="https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/getPhoneNumber.html">手机号快速验证组件</a>
+   * @param openid 用户openid，传入后微信服务端将校验其与code的绑定关系
+   * @return 用户手机号信息
+   * @throws WxErrorException .
+   * @apiNote 该接口用于将code换取用户手机号。
+   */
+  WxMaPhoneNumberInfo getPhoneNumber(String code, String openid) throws WxErrorException;
+
+  /**
    * 获取手机号信息,基础库:2.21.2及以上或2023年8月28日起
    *
    * @param code 每个code只能使用一次，code的有效期为5min。code获取方式参考<a href="https://developers.weixin.qq.com/miniprogram/dev/framework/open-ability/getPhoneNumber.html">手机号快速验证组件</a>

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaUserService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaUserService.java
@@ -82,7 +82,9 @@ public interface WxMaUserService {
    * @throws WxErrorException .
    * @apiNote 该接口用于将code换取用户手机号。
    */
-  WxMaPhoneNumberInfo getPhoneNumber(String code, String openid) throws WxErrorException;
+  default WxMaPhoneNumberInfo getPhoneNumber(String code, String openid) throws WxErrorException {
+    return this.getPhoneNumber(code);
+  }
 
   /**
    * 获取手机号信息,基础库:2.21.2及以上或2023年8月28日起

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/BaseWxMaServiceImpl.java
@@ -374,7 +374,7 @@ public abstract class BaseWxMaServiceImpl<H, P> implements WxMaService, RequestH
       Map<String, String> headers,
       String data)
       throws WxErrorException {
-    String dataForLog = "Headers: " + headers.toString() + " Body: " + data;
+    String dataForLog = "Headers: " + headers.toString() + " Body: " + DataUtils.handleDataWithSecret(data);
     return executeWithRetry(
         (uriWithAccessToken) -> executor.execute(uriWithAccessToken, headers, data, WxType.MiniApp),
         uri,

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImpl.java
@@ -67,8 +67,16 @@ public class WxMaUserServiceImpl implements WxMaUserService {
 
   @Override
   public WxMaPhoneNumberInfo getPhoneNumber(String code) throws WxErrorException {
+    return this.getPhoneNumber(code, null);
+  }
+
+  @Override
+  public WxMaPhoneNumberInfo getPhoneNumber(String code, String openid) throws WxErrorException {
     JsonObject param = new JsonObject();
     param.addProperty("code", code);
+    if (openid != null) {
+      param.addProperty("openid", openid);
+    }
     String responseContent = this.service.post(GET_PHONE_NUMBER_URL, param.toString());
     JsonObject response = GsonParser.parse(responseContent);
     if (response.has(PHONE_INFO)) {

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImpl.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImpl.java
@@ -16,6 +16,7 @@ import me.chanjar.weixin.common.error.WxErrorException;
 import me.chanjar.weixin.common.util.SignUtils;
 import me.chanjar.weixin.common.util.json.GsonParser;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -74,7 +75,7 @@ public class WxMaUserServiceImpl implements WxMaUserService {
   public WxMaPhoneNumberInfo getPhoneNumber(String code, String openid) throws WxErrorException {
     JsonObject param = new JsonObject();
     param.addProperty("code", code);
-    if (openid != null) {
+    if (StringUtils.isNotBlank(openid)) {
       param.addProperty("openid", openid);
     }
     String responseContent = this.service.post(GET_PHONE_NUMBER_URL, param.toString());

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImplPhoneNumberTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImplPhoneNumberTest.java
@@ -1,0 +1,28 @@
+package cn.binarywang.wx.miniapp.api.impl;
+
+import cn.binarywang.wx.miniapp.api.WxMaService;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.testng.annotations.Test;
+
+import static cn.binarywang.wx.miniapp.constant.WxMaApiUrlConstants.User.GET_PHONE_NUMBER_URL;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link WxMaUserServiceImpl} 获取手机号接口的单元测试。
+ */
+public class WxMaUserServiceImplPhoneNumberTest {
+
+  @Test
+  public void shouldSendOpenidWhenGettingPhoneNumber() throws WxErrorException {
+    WxMaService wxMaService = mock(WxMaService.class);
+    when(wxMaService.post(anyString(), anyString())).thenReturn("{\"phone_info\":{}}");
+
+    new WxMaUserServiceImpl(wxMaService).getPhoneNumber("phone-code", "user-openid");
+
+    verify(wxMaService).post(GET_PHONE_NUMBER_URL, "{\"code\":\"phone-code\",\"openid\":\"user-openid\"}");
+  }
+}

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImplPhoneNumberTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaUserServiceImplPhoneNumberTest.java
@@ -1,7 +1,10 @@
 package cn.binarywang.wx.miniapp.api.impl;
 
 import cn.binarywang.wx.miniapp.api.WxMaService;
+import com.google.gson.JsonObject;
 import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.json.GsonParser;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
 import static cn.binarywang.wx.miniapp.constant.WxMaApiUrlConstants.User.GET_PHONE_NUMBER_URL;
@@ -10,6 +13,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 /**
  * {@link WxMaUserServiceImpl} 获取手机号接口的单元测试。
@@ -23,6 +28,23 @@ public class WxMaUserServiceImplPhoneNumberTest {
 
     new WxMaUserServiceImpl(wxMaService).getPhoneNumber("phone-code", "user-openid");
 
-    verify(wxMaService).post(GET_PHONE_NUMBER_URL, "{\"code\":\"phone-code\",\"openid\":\"user-openid\"}");
+    ArgumentCaptor<String> requestBody = ArgumentCaptor.forClass(String.class);
+    verify(wxMaService).post(eq(GET_PHONE_NUMBER_URL), requestBody.capture());
+    JsonObject request = GsonParser.parse(requestBody.getValue());
+    assertEquals(request.get("code").getAsString(), "phone-code");
+    assertEquals(request.get("openid").getAsString(), "user-openid");
+  }
+
+  @Test
+  public void shouldIgnoreBlankOpenidWhenGettingPhoneNumber() throws WxErrorException {
+    WxMaService wxMaService = mock(WxMaService.class);
+    when(wxMaService.post(anyString(), anyString())).thenReturn("{\"phone_info\":{}}");
+
+    new WxMaUserServiceImpl(wxMaService).getPhoneNumber("phone-code", " ");
+
+    ArgumentCaptor<String> requestBody = ArgumentCaptor.forClass(String.class);
+    verify(wxMaService).post(eq(GET_PHONE_NUMBER_URL), requestBody.capture());
+    JsonObject request = GsonParser.parse(requestBody.getValue());
+    assertFalse(request.has("openid"));
   }
 }


### PR DESCRIPTION
## 概述

为 `WxMaUserService#getPhoneNumber` 增加可选 `openid` 参数，使调用方可请求微信服务端校验 `openid` 与手机号获取凭证 `code` 的绑定关系。

## 变更

- 新增 `getPhoneNumber(String code, String openid)` 重载。
- 保留原单参数方法，并委托到新方法，维持现有行为与兼容性。
- 新增单元测试，验证请求体同时包含 `code` 和 `openid`。

## 验证

- `java -cp "weixin-java-miniapp/target/test-classes:weixin-java-miniapp/target/classes:$(< /tmp/wxjava-miniapp-test-classpath)" org.testng.TestNG -testclass cn.binarywang.wx.miniapp.api.impl.WxMaUserServiceImplPhoneNumberTest`

Fixes #4076