### PR TITLE
feat: 支持企业微信待办 API

### DIFF
--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaTodoService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpOaTodoService.java
@@ -1,0 +1,36 @@
+package me.chanjar.weixin.cp.api;
+
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.bean.oa.WxCpOaTodo;
+
+/**
+ * 企业微信待办接口。
+ *
+ * @author <a href="https://github.com/binarywang">Binary Wang</a>
+ */
+public interface WxCpOaTodoService {
+
+  /**
+   * 获取待办详情。
+   *
+   * @param userId 用户ID
+   * @param todoId 待办ID
+   * @return 待办详情
+   * @throws WxErrorException 异常
+   * @see <a href="https://developer.work.weixin.qq.com/document/path/101524">获取待办详情</a>
+   */
+  WxCpOaTodo getTodo(String userId, String todoId) throws WxErrorException;
+
+  /**
+   * 更新待办状态。
+   *
+   * @param userId 用户ID
+   * @param todoId 待办ID
+   * @param status 待办状态，0：未完成，1：已完成
+   * @return 接口响应
+   * @throws WxErrorException 异常
+   * @see <a href="https://developer.work.weixin.qq.com/document/path/101531">更新待办状态</a>
+   */
+  WxCpBaseResp updateTodoStatus(String userId, String todoId, int status) throws WxErrorException;
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/WxCpService.java
@@ -556,6 +556,13 @@ public interface WxCpService extends WxService {
   WxCpOaScheduleService getOaScheduleService();
 
   /**
+   * 获取待办相关接口的服务类对象。
+   *
+   * @return the oa todo service
+   */
+  WxCpOaTodoService getOaTodoService();
+
+  /**
    * 获取群机器人消息推送服务
    *
    * @return 群机器人消息推送服务 group robot service

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/BaseWxCpServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/BaseWxCpServiceImpl.java
@@ -68,6 +68,7 @@ public abstract class BaseWxCpServiceImpl<H, P> implements WxCpService, RequestH
   private final WxCpOaCalendarService oaCalendarService = new WxCpOaCalendarServiceImpl(this);
   private final WxCpOaMeetingRoomService oaMeetingRoomService = new WxCpOaMeetingRoomServiceImpl(this);
   private final WxCpOaScheduleService oaScheduleService = new WxCpOaOaScheduleServiceImpl(this);
+  private final WxCpOaTodoService oaTodoService = new WxCpOaTodoServiceImpl(this);
   private final WxCpAgentWorkBenchService workBenchService = new WxCpAgentWorkBenchServiceImpl(this);
   private WxCpKfService kfService = new WxCpKfServiceImpl(this);
 
@@ -711,6 +712,11 @@ public abstract class BaseWxCpServiceImpl<H, P> implements WxCpService, RequestH
   @Override
   public WxCpOaScheduleService getOaScheduleService() {
     return this.oaScheduleService;
+  }
+
+  @Override
+  public WxCpOaTodoService getOaTodoService() {
+    return this.oaTodoService;
   }
 
   @Override

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaTodoServiceImpl.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/api/impl/WxCpOaTodoServiceImpl.java
@@ -1,0 +1,43 @@
+package me.chanjar.weixin.cp.api.impl;
+
+import com.google.gson.JsonObject;
+import lombok.RequiredArgsConstructor;
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.common.util.json.GsonParser;
+import me.chanjar.weixin.cp.api.WxCpOaTodoService;
+import me.chanjar.weixin.cp.api.WxCpService;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.bean.oa.WxCpOaTodo;
+import me.chanjar.weixin.cp.util.json.WxCpGsonBuilder;
+
+import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.Oa.TODO_GET;
+import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.Oa.TODO_UPDATE_STATUS;
+
+/**
+ * 企业微信待办接口实现。
+ *
+ * @author <a href="https://github.com/binarywang">Binary Wang</a>
+ */
+@RequiredArgsConstructor
+public class WxCpOaTodoServiceImpl implements WxCpOaTodoService {
+  private final WxCpService wxCpService;
+
+  @Override
+  public WxCpOaTodo getTodo(String userId, String todoId) throws WxErrorException {
+    String url = String.format("%s?userid=%s&todoid=%s",
+      this.wxCpService.getWxCpConfigStorage().getApiUrl(TODO_GET), userId, todoId);
+    String response = this.wxCpService.get(url, null);
+    return WxCpGsonBuilder.create().fromJson(GsonParser.parse(response).get("todo"), WxCpOaTodo.class);
+  }
+
+  @Override
+  public WxCpBaseResp updateTodoStatus(String userId, String todoId, int status) throws WxErrorException {
+    JsonObject request = new JsonObject();
+    request.addProperty("userid", userId);
+    request.addProperty("todoid", todoId);
+    request.addProperty("status", status);
+    String response = this.wxCpService.post(
+      this.wxCpService.getWxCpConfigStorage().getApiUrl(TODO_UPDATE_STATUS), request.toString());
+    return WxCpBaseResp.fromJson(response);
+  }
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/WxCpOaTodo.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/bean/oa/WxCpOaTodo.java
@@ -1,0 +1,35 @@
+package me.chanjar.weixin.cp.bean.oa;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+import java.io.Serializable;
+
+/**
+ * 企业微信待办详情。
+ *
+ * @author <a href="https://github.com/binarywang">Binary Wang</a>
+ */
+@Data
+public class WxCpOaTodo implements Serializable {
+  private static final long serialVersionUID = -1114385872940730722L;
+
+  @SerializedName("todoid")
+  private String todoId;
+
+  @SerializedName("creator_userid")
+  private String creatorUserId;
+
+  private String title;
+  private String content;
+  private String url;
+  private String formid;
+
+  @SerializedName("create_time")
+  private Long createTime;
+
+  @SerializedName("finish_time")
+  private Long finishTime;
+
+  private Integer state;
+}

--- a/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
+++ b/weixin-java-cp/src/main/java/me/chanjar/weixin/cp/constant/WxCpApiPathConsts.java
@@ -399,6 +399,17 @@ public interface WxCpApiPathConsts {
     String SCHEDULE_LIST = "/cgi-bin/oa/schedule/get_by_calendar";
 
     /**
+     * 待办。
+     * https://developer.work.weixin.qq.com/document/path/101524
+     */
+    String TODO_GET = "/cgi-bin/oa/todo/get";
+    /**
+     * 更新待办状态。
+     * https://developer.work.weixin.qq.com/document/path/101531
+     */
+    String TODO_UPDATE_STATUS = "/cgi-bin/oa/todo/update_status";
+
+    /**
      * 会议
      * https://developer.work.weixin.qq.com/document/path/93626
      */

--- a/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpOaTodoServiceImplTest.java
+++ b/weixin-java-cp/src/test/java/me/chanjar/weixin/cp/api/impl/WxCpOaTodoServiceImplTest.java
@@ -1,0 +1,62 @@
+package me.chanjar.weixin.cp.api.impl;
+
+import me.chanjar.weixin.common.error.WxErrorException;
+import me.chanjar.weixin.cp.api.WxCpOaTodoService;
+import me.chanjar.weixin.cp.api.WxCpService;
+import me.chanjar.weixin.cp.bean.WxCpBaseResp;
+import me.chanjar.weixin.cp.bean.oa.WxCpOaTodo;
+import me.chanjar.weixin.cp.config.WxCpConfigStorage;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
+import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.Oa.TODO_GET;
+import static me.chanjar.weixin.cp.constant.WxCpApiPathConsts.Oa.TODO_UPDATE_STATUS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 企业微信待办接口实现测试。
+ */
+public class WxCpOaTodoServiceImplTest {
+
+  @Test
+  public void getTodoShouldUseExpectedPathAndParseResponse() throws WxErrorException {
+    WxCpService cpService = mock(WxCpService.class);
+    WxCpConfigStorage configStorage = mock(WxCpConfigStorage.class);
+    when(cpService.getWxCpConfigStorage()).thenReturn(configStorage);
+    when(configStorage.getApiUrl(TODO_GET)).thenReturn("https://api.test/oa/todo/get");
+    when(cpService.get(eq("https://api.test/oa/todo/get?userid=zhangsan&todoid=todo-1"), eq(null)))
+      .thenReturn("{\"errcode\":0,\"errmsg\":\"ok\",\"todo\":{\"todoid\":\"todo-1\",\"creator_userid\":\"lisi\",\"title\":\"日报\",\"content\":\"提交日报\",\"url\":\"https://example.test/todo/1\",\"formid\":\"form-1\",\"create_time\":1700000000,\"finish_time\":1700000100,\"state\":1}}");
+
+    WxCpOaTodoService service = new WxCpOaTodoServiceImpl(cpService);
+    WxCpOaTodo todo = service.getTodo("zhangsan", "todo-1");
+
+    assertThat(todo.getTodoId()).isEqualTo("todo-1");
+    assertThat(todo.getCreatorUserId()).isEqualTo("lisi");
+    assertThat(todo.getState()).isEqualTo(1);
+  }
+
+  @Test
+  public void updateTodoStatusShouldPostExpectedJson() throws WxErrorException {
+    WxCpService cpService = mock(WxCpService.class);
+    WxCpConfigStorage configStorage = mock(WxCpConfigStorage.class);
+    when(cpService.getWxCpConfigStorage()).thenReturn(configStorage);
+    when(configStorage.getApiUrl(TODO_UPDATE_STATUS)).thenReturn("https://api.test/oa/todo/update_status");
+    when(cpService.post(eq("https://api.test/oa/todo/update_status"), anyString()))
+      .thenReturn("{\"errcode\":0,\"errmsg\":\"ok\"}");
+
+    WxCpOaTodoService service = new WxCpOaTodoServiceImpl(cpService);
+    WxCpBaseResp response = service.updateTodoStatus("zhangsan", "todo-1", 1);
+
+    assertThat(response.success()).isTrue();
+    ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(cpService).post(eq("https://api.test/oa/todo/update_status"), bodyCaptor.capture());
+    assertThat(bodyCaptor.getValue()).contains("\"userid\":\"zhangsan\"");
+    assertThat(bodyCaptor.getValue()).contains("\"todoid\":\"todo-1\"");
+    assertThat(bodyCaptor.getValue()).contains("\"status\":1");
+  }
+}


### PR DESCRIPTION
## 概要

- 新增企业微信待办详情查询 API
- 新增企业微信待办状态更新 API
- 提供待办详情模型及离线单测

Closes #4088

## 验证

- `mvn -pl weixin-java-cp -Dmaven.test.skip=true package`
- TestNG：`WxCpOaTodoServiceImplTest`（2 passed）