### PR TITLE
fix: 兼容旧版退款提现通知解析

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/EcommerceService.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/EcommerceService.java
@@ -533,6 +533,15 @@ public interface EcommerceService {
   RefundNotifyResult parseRefundNotifyResult(String notifyData, SignatureHeader header) throws WxPayException;
 
   /**
+   * @deprecated 从 4.8.5.B 起，请改用使用 {@link SignatureHeader} 的同名方法；5.0 将移除。
+   */
+  @Deprecated
+  default RefundNotifyResult parseRefundNotifyResult(String notifyData,
+                                                     com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader header) throws WxPayException {
+    return parseRefundNotifyResult(notifyData, toUnifiedSignatureHeader(header));
+  }
+
+  /**
    * <pre>
    * 提现状态变更通知回调数据处理
    * <a href="https://pay.weixin.qq.com/doc/v3/partner/4013049135">接口文档</a>
@@ -544,6 +553,15 @@ public interface EcommerceService {
    * @throws WxPayException the wx pay exception
    */
   WithdrawNotifyResult parseWithdrawNotifyResult(String notifyData, SignatureHeader header) throws WxPayException;
+
+  /**
+   * @deprecated 从 4.8.5.B 起，请改用使用 {@link SignatureHeader} 的同名方法；5.0 将移除。
+   */
+  @Deprecated
+  default WithdrawNotifyResult parseWithdrawNotifyResult(String notifyData,
+                                                         com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader header) throws WxPayException {
+    return parseWithdrawNotifyResult(notifyData, toUnifiedSignatureHeader(header));
+  }
 
   /**
    * <pre>

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
@@ -17,4 +17,12 @@ public class LegacyEcommerceApiCompatibilityTest {
     Assert.assertNotNull(result);
     Assert.assertEquals(TradeTypeEnum.JSAPI.name(), "JSAPI");
   }
+
+  @Test
+  public void shouldKeepLegacyRefundAndWithdrawNotificationSignatures() throws Exception {
+    Class<?> legacyHeader = com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.class;
+
+    Assert.assertNotNull(EcommerceService.class.getMethod("parseRefundNotifyResult", String.class, legacyHeader));
+    Assert.assertNotNull(EcommerceService.class.getMethod("parseWithdrawNotifyResult", String.class, legacyHeader));
+  }
 }


### PR DESCRIPTION
## 背景

#4087 恢复旧版收付通模型和部分服务入口后，`parseRefundNotifyResult`、`parseWithdrawNotifyResult` 仍只接受新的 `bean.notify.SignatureHeader`，旧项目使用 `bean.ecommerce.SignatureHeader` 时无法直接升级。

## 变更

- 为退款通知解析增加已废弃的旧 `SignatureHeader` 重载
- 为提现通知解析增加已废弃的旧 `SignatureHeader` 重载
- 两个重载均复用既有 `toUnifiedSignatureHeader` 转换并委托新实现
- 增加旧方法签名的兼容性测试

## 验证

- `git diff --check`
- 当前执行环境未提供可用 Maven 可执行文件，未能运行模块构建；请由 CI 验证 Maven 测试。