### PR TITLE
fix: 消除旧通知头空值重载歧义

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/ecommerce/SignatureHeader.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/ecommerce/SignatureHeader.java
@@ -1,9 +1,9 @@
 package com.github.binarywang.wxpay.bean.ecommerce;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -13,13 +13,14 @@ import java.io.Serializable;
  *
  * @author cloudX
  */
-@Data
-@SuperBuilder
-@NoArgsConstructor
-@AllArgsConstructor
 @Deprecated
+@Getter
+@Setter
+@EqualsAndHashCode(callSuper = false)
+@ToString(callSuper = false)
 public class SignatureHeader extends com.github.binarywang.wxpay.bean.notify.SignatureHeader implements Serializable {
   private static final long serialVersionUID = -6958015499416059949L;
+
   /**
    * 已签名字符串
    */
@@ -29,4 +30,107 @@ public class SignatureHeader extends com.github.binarywang.wxpay.bean.notify.Sig
    * 证书序列号
    */
   private String serialNo;
+
+  /**
+   * 保留在旧类中的序列化字段，避免升级后反序列化旧数据时丢失。
+   */
+  private String timeStamp;
+
+  /**
+   * 保留在旧类中的序列化字段，避免升级后反序列化旧数据时丢失。
+   */
+  private String nonce;
+
+  public SignatureHeader() {
+    super();
+  }
+
+  /**
+   * 保留 4.8.4 及以前版本的构造器签名。
+   */
+  public SignatureHeader(String timeStamp, String nonce, String signed, String serialNo) {
+    setTimeStamp(timeStamp);
+    setNonce(nonce);
+    this.signed = signed;
+    this.serialNo = serialNo;
+  }
+
+  private SignatureHeader(SignatureHeaderBuilder builder) {
+    super(builder);
+    this.timeStamp = builder.timeStamp;
+    this.nonce = builder.nonce;
+    this.signed = builder.signed;
+    this.serialNo = builder.serialNo;
+  }
+
+  @Override
+  public String getTimeStamp() {
+    return this.timeStamp;
+  }
+
+  @Override
+  public void setTimeStamp(String timeStamp) {
+    super.setTimeStamp(timeStamp);
+    this.timeStamp = timeStamp;
+  }
+
+  @Override
+  public String getNonce() {
+    return this.nonce;
+  }
+
+  @Override
+  public void setNonce(String nonce) {
+    super.setNonce(nonce);
+    this.nonce = nonce;
+  }
+
+  /**
+   * 保留旧版 builder 的类型和方法返回值描述符。
+   */
+  public static SignatureHeaderBuilder builder() {
+    return new SignatureHeaderBuilder();
+  }
+
+  public static class SignatureHeaderBuilder extends com.github.binarywang.wxpay.bean.notify.SignatureHeader
+    .SignatureHeaderBuilder<SignatureHeader, SignatureHeaderBuilder> {
+    private String timeStamp;
+    private String nonce;
+    private String signed;
+    private String serialNo;
+
+    @Override
+    public SignatureHeaderBuilder timeStamp(String timeStamp) {
+      super.timeStamp(timeStamp);
+      this.timeStamp = timeStamp;
+      return this;
+    }
+
+    @Override
+    public SignatureHeaderBuilder nonce(String nonce) {
+      super.nonce(nonce);
+      this.nonce = nonce;
+      return this;
+    }
+
+    public SignatureHeaderBuilder signed(String signed) {
+      this.signed = signed;
+      return this;
+    }
+
+    public SignatureHeaderBuilder serialNo(String serialNo) {
+      this.serialNo = serialNo;
+      return this;
+    }
+
+    @Override
+    protected SignatureHeaderBuilder self() {
+      return this;
+    }
+
+    @Override
+    public SignatureHeader build() {
+      return new SignatureHeader(this);
+    }
+  }
 }

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/ecommerce/SignatureHeader.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/ecommerce/SignatureHeader.java
@@ -1,9 +1,9 @@
 package com.github.binarywang.wxpay.bean.ecommerce;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.io.Serializable;
 
@@ -14,22 +14,12 @@ import java.io.Serializable;
  * @author cloudX
  */
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Deprecated
 public class SignatureHeader extends com.github.binarywang.wxpay.bean.notify.SignatureHeader implements Serializable {
   private static final long serialVersionUID = -6958015499416059949L;
-  /**
-   * 时间戳
-   */
-  private String timeStamp;
-
-  /**
-   * 随机串
-   */
-  private String nonce;
-
   /**
    * 已签名字符串
    */

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/ecommerce/SignatureHeader.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/ecommerce/SignatureHeader.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 @Deprecated
-public class SignatureHeader implements Serializable {
+public class SignatureHeader extends com.github.binarywang.wxpay.bean.notify.SignatureHeader implements Serializable {
   private static final long serialVersionUID = -6958015499416059949L;
   /**
    * 时间戳

--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/SignatureHeader.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/bean/notify/SignatureHeader.java
@@ -1,9 +1,9 @@
 package com.github.binarywang.wxpay.bean.notify;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.io.Serializable;
 
@@ -14,7 +14,7 @@ import java.io.Serializable;
  * @author thinstar
  */
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SignatureHeader implements Serializable {

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
@@ -5,8 +5,12 @@ import com.github.binarywang.wxpay.bean.ecommerce.enums.TradeTypeEnum;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import java.util.Base64;
+
 /**
- * Compile-time compatibility checks for the pre-#4014 e-commerce API.
+ * Compatibility checks for the pre-#4014 e-commerce API.
  */
 public class LegacyEcommerceApiCompatibilityTest {
 
@@ -27,7 +31,7 @@ public class LegacyEcommerceApiCompatibilityTest {
   }
 
   @Test
-  public void shouldMakeLegacyHeaderMoreSpecificAndPreserveSignatureFields() {
+  public void shouldKeepLegacySignatureHeaderConstructorAndBuilderAbi() throws Exception {
     com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader legacyHeader =
       com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.builder()
         .timeStamp("timestamp")
@@ -36,6 +40,14 @@ public class LegacyEcommerceApiCompatibilityTest {
         .serialNo("serial-no")
         .build();
 
+    Assert.assertNotNull(com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.class.getConstructor(
+      String.class, String.class, String.class, String.class));
+    Assert.assertEquals(com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.SignatureHeaderBuilder.class,
+      com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.SignatureHeaderBuilder.class
+        .getMethod("timeStamp", String.class).getReturnType());
+    Assert.assertEquals(com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.SignatureHeaderBuilder.class,
+      com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.SignatureHeaderBuilder.class
+        .getMethod("nonce", String.class).getReturnType());
     Assert.assertTrue(com.github.binarywang.wxpay.bean.notify.SignatureHeader.class
       .isAssignableFrom(legacyHeader.getClass()));
     com.github.binarywang.wxpay.bean.notify.SignatureHeader unifiedHeader =
@@ -44,5 +56,34 @@ public class LegacyEcommerceApiCompatibilityTest {
     Assert.assertEquals(unifiedHeader.getNonce(), "nonce");
     Assert.assertEquals(unifiedHeader.getSignature(), "signed");
     Assert.assertEquals(unifiedHeader.getSerial(), "serial-no");
+  }
+
+  @Test
+  public void shouldIncludeTimestampAndNonceInLegacyHeaderEquality() {
+    com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader first =
+      new com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader("timestamp-1", "nonce", "signed", "serial-no");
+    com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader second =
+      new com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader("timestamp-2", "nonce", "signed", "serial-no");
+
+    Assert.assertNotEquals(first, second);
+  }
+
+  @Test
+  public void shouldReadLegacySerializedHeaderFields() throws Exception {
+    String legacySerializedHeader = "rO0ABXNyADpjb20uZ2l0aHViLmJpbmFyeXdhbmcud3hwYXkuYmVhbi5lY29tbWVyY2UuU2lnbmF0dXJlSGVhZGVyn3ApxLekv9MCAARMAAVub25jZXQAEkxqYXZhL2xhbmcvU3RyaW5nO0wACHNlcmlhbE5vcQB+AAFMAAZzaWduZWRxAH4AAUwACXRpbWVTdGFtcHEAfgABeHB0AAVub25jZXQACXNlcmlhbC1ub3QABnNpZ25lZHQACXRpbWVzdGFtcA==";
+    ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(
+      Base64.getDecoder().decode(legacySerializedHeader)));
+    com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader header =
+      (com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader) input.readObject();
+
+    Assert.assertEquals(header.getTimeStamp(), "timestamp");
+    Assert.assertEquals(header.getNonce(), "nonce");
+    Assert.assertEquals(header.getSigned(), "signed");
+    Assert.assertEquals(header.getSerialNo(), "serial-no");
+  }
+
+  private void shouldCompileNullNotificationHeaderCalls(EcommerceService ecommerceService) throws Exception {
+    ecommerceService.parseRefundNotifyResult("notify-data", null);
+    ecommerceService.parseWithdrawNotifyResult("notify-data", null);
   }
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
@@ -25,4 +25,23 @@ public class LegacyEcommerceApiCompatibilityTest {
     Assert.assertNotNull(EcommerceService.class.getMethod("parseRefundNotifyResult", String.class, legacyHeader));
     Assert.assertNotNull(EcommerceService.class.getMethod("parseWithdrawNotifyResult", String.class, legacyHeader));
   }
+
+  @Test
+  public void shouldMakeLegacyHeaderMoreSpecificAndPreserveSignatureFields() {
+    com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader legacyHeader =
+      new com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader();
+    legacyHeader.setTimeStamp("timestamp");
+    legacyHeader.setNonce("nonce");
+    legacyHeader.setSigned("signed");
+    legacyHeader.setSerialNo("serial-no");
+
+    Assert.assertTrue(com.github.binarywang.wxpay.bean.notify.SignatureHeader.class
+      .isAssignableFrom(legacyHeader.getClass()));
+    com.github.binarywang.wxpay.bean.notify.SignatureHeader unifiedHeader =
+      EcommerceService.toUnifiedSignatureHeader(legacyHeader);
+    Assert.assertEquals(unifiedHeader.getTimeStamp(), "timestamp");
+    Assert.assertEquals(unifiedHeader.getNonce(), "nonce");
+    Assert.assertEquals(unifiedHeader.getSignature(), "signed");
+    Assert.assertEquals(unifiedHeader.getSerial(), "serial-no");
+  }
 }

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
@@ -29,11 +29,12 @@ public class LegacyEcommerceApiCompatibilityTest {
   @Test
   public void shouldMakeLegacyHeaderMoreSpecificAndPreserveSignatureFields() {
     com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader legacyHeader =
-      new com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader();
-    legacyHeader.setTimeStamp("timestamp");
-    legacyHeader.setNonce("nonce");
-    legacyHeader.setSigned("signed");
-    legacyHeader.setSerialNo("serial-no");
+      com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader.builder()
+        .timeStamp("timestamp")
+        .nonce("nonce")
+        .signed("signed")
+        .serialNo("serial-no")
+        .build();
 
     Assert.assertTrue(com.github.binarywang.wxpay.bean.notify.SignatureHeader.class
       .isAssignableFrom(legacyHeader.getClass()));


### PR DESCRIPTION
## 背景

#4095 为旧版退款、提现通知解析添加 `bean.ecommerce.SignatureHeader` 重载后，`parse*NotifyResult(notifyData, null)` 因两个无关参数类型而出现编译期重载歧义。

## 变更

- 使旧 `bean.ecommerce.SignatureHeader` 继承新的 `bean.notify.SignatureHeader`
- 保留旧字段 `signed`、`serialNo`，并继续通过适配器映射到新的 `signature`、`serial`
- 旧参数类型因此成为更具体的重载类型，原有 `null` 调用不再二义
- 增加类型关系与字段映射回归测试

## 验证

- `git diff --check`
- 当前环境未安装 Maven；请由 CI 运行模块测试。