### PR TITLE
fix: 修正小程序服务卡片接口地址

### DIFF
--- a/weixin-java-miniapp/pom.xml
+++ b/weixin-java-miniapp/pom.xml
@@ -115,6 +115,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <skip>false</skip>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
           </suiteXmlFiles>

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaSubscribeService.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/api/WxMaSubscribeService.java
@@ -122,7 +122,7 @@ public interface WxMaSubscribeService {
    * 激活与更新服务卡片
    *
    * 详情请见: <a href="https://developers.weixin.qq.com/miniprogram/dev/server/API/mp-message-management/subscribe-message/api_setusernotify.html">激活与更新服务卡片</a>
-   * 接口url格式: POST https://api.weixin.qq.com/wxa/setusernotify?access_token=ACCESS_TOKEN
+   * 接口url格式: POST https://api.weixin.qq.com/wxa/set_user_notify?access_token=ACCESS_TOKEN
    * </pre>
    *
    * @param request 请求参数
@@ -135,7 +135,7 @@ public interface WxMaSubscribeService {
    * 更新服务卡片扩展信息
    *
    * 详情请见: <a href="https://developers.weixin.qq.com/miniprogram/dev/server/API/mp-message-management/subscribe-message/api_setusernotifyext.html">更新服务卡片扩展信息</a>
-   * 接口url格式: POST https://api.weixin.qq.com/wxa/setusernotifyext?access_token=ACCESS_TOKEN
+   * 接口url格式: POST https://api.weixin.qq.com/wxa/set_user_notifyext?access_token=ACCESS_TOKEN
    * </pre>
    *
    * @param request 请求参数
@@ -148,7 +148,7 @@ public interface WxMaSubscribeService {
    * 查询服务卡片状态
    *
    * 详情请见: <a href="https://developers.weixin.qq.com/miniprogram/dev/server/API/mp-message-management/subscribe-message/api_getusernotify.html">查询服务卡片状态</a>
-   * 接口url格式: POST https://api.weixin.qq.com/wxa/getusernotify?access_token=ACCESS_TOKEN
+   * 接口url格式: POST https://api.weixin.qq.com/wxa/get_user_notify?access_token=ACCESS_TOKEN
    * </pre>
    *
    * @param request 请求参数

--- a/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/constant/WxMaApiUrlConstants.java
+++ b/weixin-java-miniapp/src/main/java/cn/binarywang/wx/miniapp/constant/WxMaApiUrlConstants.java
@@ -370,13 +370,13 @@ public class WxMaApiUrlConstants {
     String SUBSCRIBE_MSG_SEND_URL = "https://api.weixin.qq.com/cgi-bin/message/subscribe/send";
 
     /** 激活与更新服务卡片 */
-    String SERVICE_NOTIFY_SET_URL = "https://api.weixin.qq.com/wxa/setusernotify";
+    String SERVICE_NOTIFY_SET_URL = "https://api.weixin.qq.com/wxa/set_user_notify";
 
     /** 更新服务卡片扩展信息 */
-    String SERVICE_NOTIFY_SET_EXT_URL = "https://api.weixin.qq.com/wxa/setusernotifyext";
+    String SERVICE_NOTIFY_SET_EXT_URL = "https://api.weixin.qq.com/wxa/set_user_notifyext";
 
     /** 查询服务卡片状态 */
-    String SERVICE_NOTIFY_GET_URL = "https://api.weixin.qq.com/wxa/getusernotify";
+    String SERVICE_NOTIFY_GET_URL = "https://api.weixin.qq.com/wxa/get_user_notify";
   }
 
   public interface User {

--- a/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaSubscribeServiceImplUrlTest.java
+++ b/weixin-java-miniapp/src/test/java/cn/binarywang/wx/miniapp/api/impl/WxMaSubscribeServiceImplUrlTest.java
@@ -1,0 +1,55 @@
+package cn.binarywang.wx.miniapp.api.impl;
+
+import cn.binarywang.wx.miniapp.api.WxMaService;
+import cn.binarywang.wx.miniapp.api.WxMaSubscribeService;
+import cn.binarywang.wx.miniapp.bean.WxMaGetUserNotifyRequest;
+import cn.binarywang.wx.miniapp.bean.WxMaServiceNotifyExtRequest;
+import cn.binarywang.wx.miniapp.bean.WxMaServiceNotifyRequest;
+import me.chanjar.weixin.common.error.WxErrorException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WxMaSubscribeServiceImplUrlTest {
+
+  @Test
+  public void setUserNotifyUsesOfficialEndpoint() throws WxErrorException {
+    WxMaService service = successService();
+
+    subscribeService(service).setUserNotify(WxMaServiceNotifyRequest.builder().build());
+
+    verify(service).post(eq("https://api.weixin.qq.com/wxa/set_user_notify"), anyString());
+  }
+
+  @Test
+  public void setUserNotifyExtUsesOfficialEndpoint() throws WxErrorException {
+    WxMaService service = successService();
+
+    subscribeService(service).setUserNotifyExt(WxMaServiceNotifyExtRequest.builder().build());
+
+    verify(service).post(eq("https://api.weixin.qq.com/wxa/set_user_notifyext"), anyString());
+  }
+
+  @Test
+  public void getUserNotifyUsesOfficialEndpoint() throws WxErrorException {
+    WxMaService service = successService();
+
+    subscribeService(service).getUserNotify(WxMaGetUserNotifyRequest.builder().build());
+
+    verify(service).post(eq("https://api.weixin.qq.com/wxa/get_user_notify"), anyString());
+  }
+
+  private WxMaSubscribeService subscribeService(WxMaService service) {
+    return new WxMaSubscribeServiceImpl(service);
+  }
+
+  private WxMaService successService() throws WxErrorException {
+    WxMaService service = Mockito.mock(WxMaService.class);
+    when(service.post(anyString(), anyString())).thenReturn("{\"errcode\":0,\"errmsg\":\"ok\"}");
+    return service;
+  }
+}

--- a/weixin-java-miniapp/src/test/resources/testng.xml
+++ b/weixin-java-miniapp/src/test/resources/testng.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="weixin-java-miniapp-unit-tests" verbose="1">
+  <test name="Unit_Test">
+    <classes>
+      <class name="cn.binarywang.wx.miniapp.api.impl.WxMaSubscribeServiceImplUrlTest"/>
+    </classes>
+  </test>
+</suite>


### PR DESCRIPTION
## 修复内容

- 修正服务卡片三个接口 URL 中缺失的下划线
- 同步修正公开 Javadoc 中的接口地址
- 新增独立单元测试，验证三个服务方法的实际 POST URL

Fixes #4101

## 验证

- `mvn -pl weixin-java-miniapp test-compile`
- `java -cp ... org.testng.TestNG -testclass cn.binarywang.wx.miniapp.api.impl.WxMaSubscribeServiceImplUrlTest`（3 passed）