### PR TITLE
fix(miniapp): 修复发布构建中的测试跳过冲突

### DIFF
--- a/weixin-java-miniapp/pom.xml
+++ b/weixin-java-miniapp/pom.xml
@@ -115,7 +115,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skip>false</skip>
+          <skip>${maven.test.skip}</skip>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
           </suiteXmlFiles>


### PR DESCRIPTION
## 问题
发布工作流使用 `-Dmaven.test.skip=true` 跳过测试编译，但 miniapp 模块固定 Surefire 的 `<skip>false</skip>`，导致 TestNG 执行 suite 时找不到未编译的 `WxMaSubscribeServiceImplUrlTest`。

## 修复
让 Surefire 的 `skip` 读取 `${maven.test.skip}`，使发布流程一致跳过测试编译与执行；常规构建仍运行该 TestNG suite。

## 验证
- `mvn -pl weixin-java-miniapp clean test -Dmaven.test.skip=true -Dgpg.skip=true --no-transfer-progress`
- `mvn -pl weixin-java-miniapp clean test -Dgpg.skip=true --no-transfer-progress`（3 tests, 0 failures）