### PR TITLE
fix: 修复电商旧接口closePartnerTransactions丢失outTradeNo (#4114)

### DIFF
--- a/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/EcommerceService.java
+++ b/weixin-java-pay/src/main/java/com/github/binarywang/wxpay/service/EcommerceService.java
@@ -109,7 +109,7 @@ public interface EcommerceService {
   /** @deprecated 从 4.8.5.B 起，请改用 {@link #closePartnerOrder(WxPayPartnerOrderCloseV3Request)}；5.0 将移除。 */
   @Deprecated
   default String closePartnerTransactions(com.github.binarywang.wxpay.bean.ecommerce.PartnerTransactionsCloseRequest request) throws WxPayException {
-    closePartnerOrder(LEGACY_ECOMMERCE_GSON.fromJson(LEGACY_ECOMMERCE_GSON.toJson(request), WxPayPartnerOrderCloseV3Request.class));
+    closePartnerOrder(toUnifiedPartnerOrderCloseRequest(request));
     return null;
   }
 
@@ -120,6 +120,21 @@ public interface EcommerceService {
   static SignatureHeader toUnifiedSignatureHeader(com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader header) {
     return header == null ? null : SignatureHeader.builder().timeStamp(header.getTimeStamp()).nonce(header.getNonce())
       .signature(header.getSigned()).serial(header.getSerialNo()).build();
+  }
+
+  /**
+   * 旧电商关闭请求转统一模型。
+   * <p>{@code outTradeNo} 在两侧均为 path 参数（{@code transient}），不能走 Gson 往返，否则会丢失。
+   */
+  static WxPayPartnerOrderCloseV3Request toUnifiedPartnerOrderCloseRequest(
+      com.github.binarywang.wxpay.bean.ecommerce.PartnerTransactionsCloseRequest request) {
+    if (request == null) {
+      return null;
+    }
+    return new WxPayPartnerOrderCloseV3Request()
+      .setSpMchId(request.getSpMchid())
+      .setSubMchId(request.getSubMchid())
+      .setOutTradeNo(request.getOutTradeNo());
   }
 
   /**

--- a/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
+++ b/weixin-java-pay/src/test/java/com/github/binarywang/wxpay/service/LegacyEcommerceApiCompatibilityTest.java
@@ -1,7 +1,9 @@
 package com.github.binarywang.wxpay.service;
 
+import com.github.binarywang.wxpay.bean.ecommerce.PartnerTransactionsCloseRequest;
 import com.github.binarywang.wxpay.bean.ecommerce.TransactionsResult;
 import com.github.binarywang.wxpay.bean.ecommerce.enums.TradeTypeEnum;
+import com.github.binarywang.wxpay.bean.request.WxPayPartnerOrderCloseV3Request;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -66,6 +68,21 @@ public class LegacyEcommerceApiCompatibilityTest {
       new com.github.binarywang.wxpay.bean.ecommerce.SignatureHeader("timestamp-2", "nonce", "signed", "serial-no");
 
     Assert.assertNotEquals(first, second);
+  }
+
+  @Test
+  public void shouldPreserveOutTradeNoWhenMappingLegacyCloseRequest() {
+    PartnerTransactionsCloseRequest legacyRequest = new PartnerTransactionsCloseRequest();
+    legacyRequest.setSpMchid("1230000109");
+    legacyRequest.setSubMchid("1900000109");
+    legacyRequest.setOutTradeNo("1217752501201407033233368018");
+
+    WxPayPartnerOrderCloseV3Request unifiedRequest =
+      EcommerceService.toUnifiedPartnerOrderCloseRequest(legacyRequest);
+
+    Assert.assertEquals(unifiedRequest.getSpMchId(), "1230000109");
+    Assert.assertEquals(unifiedRequest.getSubMchId(), "1900000109");
+    Assert.assertEquals(unifiedRequest.getOutTradeNo(), "1217752501201407033233368018");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- 修复微信支付模块 `closePartnerTransactions` 接口调用时丢失 `outTradeNo` 参数的问题 (#4114)

## Changes
- 补全 `outTradeNo` 字段传递，确保关闭合作伙伴交易接口参数完整